### PR TITLE
feat: Refactor LLM routes to use LLMRegistryService and add tests

### DIFF
--- a/backend/app/routes/llm_routes.py
+++ b/backend/app/routes/llm_routes.py
@@ -1,15 +1,12 @@
 import logging
 import time # Added for timestamp in ChatCompletionResponse
-import shutil # For saving uploaded files
-from pathlib import Path # For path manipulation
 from typing import List, Optional, Dict, Any, Union, AsyncGenerator # Added AsyncGenerator
 from fastapi import APIRouter, Depends, HTTPException, Body, UploadFile, File
 from fastapi.responses import StreamingResponse # Added for TTS
 from pydantic import BaseModel, Field, HttpUrl
 
-import httpx # Added for making HTTP requests
+import httpx # Added for making HTTP requests (still needed for error types)
 from ..utils.llm_registry_service import get_llm_registry_service, LLMRegistryService
-from ..app_config import LITELLM_PROXY_URL, LITELLM_PROXY_API_KEY # Import LiteLLM config
 
 # Imports for Tool Calling API Endpoints
 from ..services.tool_calling.tool_schema_manager import ToolSchemaManager
@@ -225,13 +222,6 @@ class AudioTranscriptionResponse(BaseModel):
     words: Optional[List[Dict[str, Any]]] = None # For verbose_json with word timestamps
 
 
-# Temporary storage for uploaded audio files
-TEMP_AUDIO_DIR = Path("temp_audio_uploads")
-TEMP_AUDIO_DIR.mkdir(parents=True, exist_ok=True)
-
-TEMP_TTS_DIR = Path("temp_tts_audio") # For Text-to-Speech output
-TEMP_TTS_DIR.mkdir(parents=True, exist_ok=True)
-
 # --- Pydantic Models for Text-to-Speech ---
 
 class TextToSpeechRequest(BaseModel):
@@ -364,62 +354,64 @@ async def chat_completions(
         # Remove None values from the payload to avoid sending nulls for optional fields
         litellm_payload = {k: v for k, v in litellm_payload.items() if v is not None}
 
-        logger.info(f"Sending chat completion request to LiteLLM proxy: {LITELLM_PROXY_URL}/v1/chat/completions")
-        
-        headers = {}
-        if LITELLM_PROXY_API_KEY:
-            headers["Authorization"] = f"Bearer {LITELLM_PROXY_API_KEY}"
+        # Process tools for the service call
+        tools_for_litellm = [tool.model_dump(exclude_none=True) for tool in request_body.tools] if request_body.tools else None
 
-        async with httpx.AsyncClient(timeout=120.0) as client: # Use httpx to call the proxy
-            response = await client.post(
-                f"{LITELLM_PROXY_URL}/v1/chat/completions",
-                json=litellm_payload,
-                headers=headers
-            )
-            response.raise_for_status() # Raise an exception for bad status codes (4xx or 5xx)
-            
-            # If streaming, return a StreamingResponse
-            if request_body.stream:
-                async def stream_response():
-                    async for chunk in response.aiter_bytes():
-                        yield chunk
-                # Determine media type - text/event-stream for SSE
-                return StreamingResponse(stream_response(), media_type="text/event-stream")
+        logger.info(f"Calling chat_completion_advanced service for model_alias: {request_body.model_alias}")
 
-            # If not streaming, parse the JSON response
-            litellm_response_data = response.json()
+        service_response = await llm_registry.chat_completion_advanced(
+            model_alias=request_body.model_alias,
+            messages=messages_for_litellm,
+            temperature=request_body.temperature,
+            max_tokens=request_body.max_tokens,
+            stream=request_body.stream,
+            user=request_body.user,
+            tools=tools_for_litellm,
+            tool_choice=request_body.tool_choice,
+            safety_settings=request_body.safety_settings,
+            thinking=request_body.thinking,
+            reasoning_effort=request_body.reasoning_effort,
+            cache_control=request_body.cache_control,
+            extra_body=request_body.extra_body
+            # request_timeout is not explicitly passed here, using service default
+        )
 
-        # Map LiteLLM's response structure to our ChatCompletionResponse Pydantic model.
-        # LiteLLM's response should be compatible with OpenAI's ChatCompletionResponse.
-        # We can directly use the Pydantic model's parsing capabilities.
-        
-        # Ensure the 'model' field in the response is the actual model used by LiteLLM
-        actual_model_used = litellm_response_data.get("model", request_body.model_alias)
-        litellm_response_data['model'] = actual_model_used # Ensure our model uses the actual model ID
+        if request_body.stream:
+            # service_response is an AsyncGenerator
+            return StreamingResponse(service_response, media_type="text/event-stream")
+        else:
+            # service_response is a Dict
+            # Ensure the 'model' field in the response is the actual model used by LiteLLM,
+            # as the service might get this from LiteLLM's response.
+            # If not present in service_response, use the requested alias (though it should be there).
+            actual_model_used = service_response.get("model", request_body.model_alias)
+            service_response['model'] = actual_model_used
 
-        # Use the Pydantic model to parse the response data
-        return ChatCompletionResponse(**litellm_response_data)
+            # The service_response should be directly usable by ChatCompletionResponse
+            # if it matches the OpenAI/LiteLLM format.
+            return ChatCompletionResponse(**service_response)
 
     except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error calling LiteLLM proxy chat endpoint ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
-        # Attempt to parse error details from the response body if available
-        error_detail = f"LLM proxy returned an HTTP error: {e.response.status_code}"
+        logger.error(f"HTTP error from LLM service during chat completion ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
+        error_detail = f"LLM service returned an HTTP error: {e.response.status_code}"
         try:
             error_response_data = e.response.json()
             if "error" in error_response_data and isinstance(error_response_data["error"], dict):
-                 error_detail += f" - {error_response_data['error'].get('message', 'Unknown error from proxy')}"
-            elif "detail" in error_response_data:
+                 error_detail += f" - {error_response_data['error'].get('message', 'Unknown error from LLM service')}"
+            elif "detail" in error_response_data: # Some proxies might use 'detail'
                  error_detail += f" - {error_response_data['detail']}"
-            else:
-                 error_detail += f" - {e.response.text}" # Fallback to raw text
-        except json.JSONDecodeError:
-            error_detail += f" - {e.response.text}" # Fallback to raw text if JSON parsing fails
-            
+            else: # Fallback if error structure is unknown
+                 error_detail += f" - {e.response.text[:200]}" # Limit length
+        except json.JSONDecodeError: # If the error response itself is not JSON
+            error_detail += f" - {e.response.text[:200]}"
         raise HTTPException(status_code=e.response.status_code, detail=error_detail)
     except httpx.RequestError as e:
-        logger.error(f"Request error calling LiteLLM proxy chat endpoint ({e.request.url}): {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to connect to LLM proxy: {e}")
-    except Exception as e:
+        logger.error(f"Request error connecting to LLM service during chat completion ({e.request.url}): {e}", exc_info=True)
+        raise HTTPException(status_code=503, detail=f"Failed to connect to LLM service: {str(e)}") # 503 Service Unavailable
+    except json.JSONDecodeError as e: # If service returns non-JSON for non-streaming, or if ChatCompletionResponse parsing fails
+        logger.error(f"JSON decode error processing response from LLM service for chat completion: {e.msg}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Invalid JSON response from LLM service: {e.msg}")
+    except Exception as e: # Catch-all for other unexpected errors
         logger.error(f"Unexpected error during chat completion for model_alias {request_body.model_alias}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {str(e)}")
 
@@ -441,53 +433,47 @@ async def create_embeddings(
             # Add other parameters like encoding_format, user if supported and needed
         }
         
-        logger.info(f"Sending embedding request to LiteLLM proxy: {LITELLM_PROXY_URL}/v1/embeddings")
-        
-        headers = {}
-        if LITELLM_PROXY_API_KEY:
-            headers["Authorization"] = f"Bearer {LITELLM_PROXY_API_KEY}"
+        # The EmbeddingRequest model does not currently have an 'extra_body' field.
+        # If it were to be added, it could be accessed like:
+        # extra_body_payload = getattr(request_body, 'extra_body', None)
+        # For now, we pass None as the service method handles it.
+        extra_body_payload = None 
 
-        async with httpx.AsyncClient(timeout=60.0) as client: # Use httpx to call the proxy
-            response = await client.post(
-                f"{LITELLM_PROXY_URL}/v1/embeddings",
-                json=litellm_payload,
-                headers=headers
-            )
-            response.raise_for_status() # Raise an exception for bad status codes (4xx or 5xx)
-            
-            litellm_embedding_response = response.json()
+        logger.info(f"Calling create_embeddings_advanced service for model_alias: {request_body.model_alias}")
 
-        # Map LiteLLM's embedding response structure to our EmbeddingResponse Pydantic model.
-        # LiteLLM's response should be compatible with OpenAI's EmbeddingResponse.
-        # We can directly use the Pydantic model's parsing capabilities.
-        
-        # Ensure the 'model' field in the response is the actual model used by LiteLLM
-        actual_model_used = litellm_embedding_response.get("model", request_body.model_alias)
-        litellm_embedding_response['model'] = actual_model_used # Ensure our model uses the actual model ID
+        service_response_dict = await llm_registry.create_embeddings_advanced(
+            model_alias=request_body.model_alias,
+            input_data=request_body.input,
+            extra_body=extra_body_payload
+            # request_timeout can be passed if desired, using service default for now
+        )
 
-        # Use the Pydantic model to parse the response data
-        return EmbeddingResponse(**litellm_embedding_response)
+        # The service_response_dict should contain the 'model' field as returned by LiteLLM.
+        # EmbeddingResponse Pydantic model will validate this.
+        return EmbeddingResponse(**service_response_dict)
 
     except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error calling LiteLLM proxy embeddings endpoint ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
-        error_detail = f"LLM proxy returned an HTTP error: {e.response.status_code}"
+        logger.error(f"HTTP error from LLM service during embedding creation ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
+        error_detail = f"LLM service returned an HTTP error: {e.response.status_code}"
         try:
             error_response_data = e.response.json()
             if "error" in error_response_data and isinstance(error_response_data["error"], dict):
-                 error_detail += f" - {error_response_data['error'].get('message', 'Unknown error from proxy')}"
+                 error_detail += f" - {error_response_data['error'].get('message', 'Unknown error from LLM service')}"
             elif "detail" in error_response_data:
                  error_detail += f" - {error_response_data['detail']}"
             else:
-                 error_detail += f" - {e.response.text}" # Fallback to raw text
+                 error_detail += f" - {e.response.text[:200]}" # Limit length
         except json.JSONDecodeError:
-            error_detail += f" - {e.response.text}" # Fallback to raw text if JSON parsing fails
-            
+            error_detail += f" - {e.response.text[:200]}"
         raise HTTPException(status_code=e.response.status_code, detail=error_detail)
     except httpx.RequestError as e:
-        logger.error(f"Request error calling LiteLLM proxy embeddings endpoint ({e.request.url}): {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to connect to LLM proxy: {e}")
-    except Exception as e:
-        logger.error(f"Unexpected error during embedding generation for model_alias {request_body.model_alias}: {e}", exc_info=True)
+        logger.error(f"Request error connecting to LLM service during embedding creation ({e.request.url}): {e}", exc_info=True)
+        raise HTTPException(status_code=503, detail=f"Failed to connect to LLM service: {str(e)}") # 503 Service Unavailable
+    except json.JSONDecodeError as e: # If service returns non-JSON or EmbeddingResponse parsing fails
+        logger.error(f"JSON decode error processing response from LLM service for embedding creation: {e.msg}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Invalid JSON response from LLM service: {e.msg}")
+    except Exception as e: # Catch-all for other unexpected errors
+        logger.error(f"Unexpected error during embedding creation for model_alias {request_body.model_alias}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {str(e)}")
 
 @router.post("/llm/generate-image", response_model=ImageGenerationResponse, tags=["LLM Endpoints"])
@@ -501,64 +487,61 @@ async def create_image_generation(
     try:
         logger.info(f"Received image generation request for model_alias: {request_body.model_alias}")
 
-        # Construct the payload for the LiteLLM proxy's /v1/images/generations endpoint
-        litellm_payload = {
-            "model": request_body.model_alias, # Use the alias as the model name for the proxy
-            "prompt": request_body.prompt,
-            "n": request_body.n,
-            "size": request_body.size,
-            "quality": request_body.quality,
-            "style": request_body.style,
-            "response_format": request_body.response_format,
-            # user=request_body.user
-        }
-        
-        # Remove None values from the payload
-        litellm_payload = {k: v for k, v in litellm_payload.items() if v is not None}
+        # ImageGenerationRequest doesn't currently have extra_body.
+        # If it needs to support extra_body, it should be added to its Pydantic model.
+        extra_body_payload = getattr(request_body, 'extra_body', None)
 
-        logger.info(f"Sending image generation request to LiteLLM proxy: {LITELLM_PROXY_URL}/v1/images/generations")
-        
-        headers = {}
-        if LITELLM_PROXY_API_KEY:
-            headers["Authorization"] = f"Bearer {LITELLM_PROXY_API_KEY}"
+        logger.info(f"Calling generate_image_advanced service for model_alias: {request_body.model_alias}")
 
-        async with httpx.AsyncClient(timeout=120.0) as client: # Use httpx to call the proxy
-            response = await client.post(
-                f"{LITELLM_PROXY_URL}/v1/images/generations",
-                json=litellm_payload,
-                headers=headers
-            )
-            response.raise_for_status() # Raise an exception for bad status codes (4xx or 5xx)
-            
-            litellm_image_response = response.json()
+        service_response_dict = await llm_registry.generate_image_advanced(
+            model_alias=request_body.model_alias,
+            prompt=request_body.prompt,
+            n=request_body.n,
+            size=request_body.size,
+            quality=request_body.quality,
+            style=request_body.style,
+            response_format=request_body.response_format,
+            extra_body=extra_body_payload
+            # request_timeout can be passed if desired, using service default for now
+        )
 
-        # Map LiteLLM's image generation response structure to our ImageGenerationResponse Pydantic model.
-        # LiteLLM's response should be compatible with OpenAI's ImageGenerationResponse.
-        # We can directly use the Pydantic model's parsing capabilities.
-        
-        return ImageGenerationResponse(**litellm_image_response)
+        # The service_response_dict should be directly parsable by ImageGenerationResponse.
+        # LiteLLM's response for image generation typically includes 'created' and 'data' fields.
+        return ImageGenerationResponse(**service_response_dict)
 
     except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error calling LiteLLM proxy image generation endpoint ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
-        error_detail = f"LLM proxy returned an HTTP error: {e.response.status_code}"
+        logger.error(f"HTTP error from LLM service during image generation ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
+        error_detail = f"LLM service returned an HTTP error: {e.response.status_code}"
         try:
             error_response_data = e.response.json()
             if "error" in error_response_data and isinstance(error_response_data["error"], dict):
-                 error_detail += f" - {error_response_data['error'].get('message', 'Unknown error from proxy')}"
+                 error_detail += f" - {error_response_data['error'].get('message', 'Unknown error from LLM service')}"
             elif "detail" in error_response_data:
                  error_detail += f" - {error_response_data['detail']}"
             else:
-                 error_detail += f" - {e.response.text}" # Fallback to raw text
+                 error_detail += f" - {e.response.text[:200]}" # Limit length
         except json.JSONDecodeError:
-            error_detail += f" - {e.response.text}" # Fallback to raw text if JSON parsing fails
-            
+            error_detail += f" - {e.response.text[:200]}"
         raise HTTPException(status_code=e.response.status_code, detail=error_detail)
     except httpx.RequestError as e:
-        logger.error(f"Request error calling LiteLLM proxy image generation endpoint ({e.request.url}): {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to connect to LLM proxy: {e}")
-    except Exception as e:
+        logger.error(f"Request error connecting to LLM service during image generation ({e.request.url}): {e}", exc_info=True)
+        raise HTTPException(status_code=503, detail=f"Failed to connect to LLM service: {str(e)}") # 503 Service Unavailable
+    except json.JSONDecodeError as e: # If service returns non-JSON or ImageGenerationResponse parsing fails
+        logger.error(f"JSON decode error processing response from LLM service for image generation: {e.msg}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Invalid JSON response from LLM service: {e.msg}")
+    except Exception as e: # Catch-all for other unexpected errors
         logger.error(f"Unexpected error during image generation for model_alias {request_body.model_alias}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {str(e)}")
+
+
+# The /llm/text-completion endpoint seems to be a new addition not covered by previous refactoring tasks.
+# If it was intended to be refactored, it would follow a similar pattern,
+# potentially using llm_registry.chat_completion_advanced with a specific prompt structure
+# or a new service method llm_registry.text_completion_advanced if the /v1/completions
+# endpoint in LiteLLM has significantly different parameters or response structures than chat.
+# For now, I will assume this endpoint is either new or intentionally not yet refactored,
+# as the task was to clean up after the six specified "advanced" methods.
+# If this endpoint also needs refactoring to use a service method, that would be a separate step.
 
 @router.post("/llm/text-completion", response_model=TextCompletionResponse, tags=["LLM Endpoints"])
 async def create_text_completion(
@@ -658,107 +641,66 @@ async def create_audio_transcription(
     Endpoint for transcribing audio using a registered LLM.
     Accepts audio file via multipart/form-data.
     """
-    temp_file_path: Optional[Path] = None
     try:
         logger.info(f"Received audio transcription request for model_alias: {model_alias}, filename: {file.filename}")
 
-        # Save UploadFile to a temporary file, as LiteLLM expects a file path
-        # Ensure the temp directory exists
-        TEMP_AUDIO_DIR.mkdir(parents=True, exist_ok=True)
+        file_data = await file.read()
         
-        # Create a unique temporary filename
-        temp_file_path = TEMP_AUDIO_DIR / f"{time.time_ns()}_{file.filename}"
-        
-        with open(temp_file_path, "wb") as buffer:
-            shutil.copyfileobj(file.file, buffer)
-        
-        logger.info(f"Temporary audio file saved to: {temp_file_path}")
+        # The route currently doesn't explicitly collect 'extra_form_data'.
+        # If this is needed, the route signature or logic would have to change
+        # to gather additional Body fields into a dict. For now, pass None.
+        extra_data_payload = None
 
-        # Construct the payload for the LiteLLM proxy's /v1/audio/transcriptions endpoint
-        # This endpoint expects multipart/form-data
-        litellm_data = {
-            "model": model_alias, # Use the alias as the model name for the proxy
-            "language": language,
-            "prompt": prompt,
-            "response_format": response_format,
-            "temperature": temperature,
-            # Add other parameters as needed
-        }
-        
-        # Remove None values from the data payload
-        litellm_data = {k: v for k, v in litellm_data.items() if v is not None}
+        logger.info(f"Calling transcribe_audio_advanced service for model_alias: {model_alias}")
 
-        # Prepare the file for sending
-        files = {"file": (file.filename, open(temp_file_path, "rb"), file.content_type)}
+        service_response = await llm_registry.transcribe_audio_advanced(
+            model_alias=model_alias,
+            file_name=file.filename,
+            file_data=file_data,
+            content_type=file.content_type,
+            language=language,
+            prompt=prompt,
+            response_format=response_format,
+            temperature=temperature,
+            extra_form_data=extra_data_payload
+            # request_timeout can be passed if desired, using service default for now
+        )
 
-        logger.info(f"Sending audio transcription request to LiteLLM proxy: {LITELLM_PROXY_URL}/v1/audio/transcriptions")
-        
-        headers = {}
-        if LITELLM_PROXY_API_KEY:
-            headers["Authorization"] = f"Bearer {LITELLM_PROXY_API_KEY}"
-
-        async with httpx.AsyncClient(timeout=300.0) as client: # Use httpx to call the proxy
-            response = await client.post(
-                f"{LITELLM_PROXY_URL}/v1/audio/transcriptions",
-                data=litellm_data,
-                files=files,
-                headers=headers
-            )
-            response.raise_for_status() # Raise an exception for bad status codes (4xx or 5xx)
-            
-            # LiteLLM's transcription response can be a string (text, srt, vtt) or JSON (json, verbose_json)
-            # We need to handle both cases.
-            content_type = response.headers.get("Content-Type", "")
-            if "application/json" in content_type:
-                litellm_transcription_response = response.json()
-            else:
-                litellm_transcription_response = response.text # Assume text-based format
-
-        # Map LiteLLM's audio transcription response structure to our AudioTranscriptionResponse Pydantic model.
-        # If the response is a string, wrap it in the Pydantic model. If it's a dict, parse it.
-        
-        if isinstance(litellm_transcription_response, str):
-             return AudioTranscriptionResponse(text=litellm_transcription_response)
-        elif isinstance(litellm_transcription_response, dict):
-             # Use the Pydantic model to parse the response data
-             return AudioTranscriptionResponse(**litellm_transcription_response)
+        if isinstance(service_response, str):
+            # For text, srt, vtt formats, FastAPI will handle Content-Type as text/plain
+            return service_response 
+        elif isinstance(service_response, dict):
+            # For json, verbose_json formats
+            return AudioTranscriptionResponse(**service_response)
         else:
-            logger.error(f"Unexpected response type from LiteLLM transcription: {type(litellm_transcription_response)}. Expected str or dict.")
-            raise HTTPException(status_code=500, detail="Audio transcription failed: Unexpected response format from proxy.")
-
+            # Should not happen based on service method's return type hint, but good for safety
+            logger.error(f"Unexpected response type from LLM service transcription: {type(service_response)}. Expected str or dict.")
+            raise HTTPException(status_code=500, detail="Audio transcription failed: Unexpected response format from LLM service.")
 
     except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error calling LiteLLM proxy transcription endpoint ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
-        error_detail = f"LLM proxy returned an HTTP error: {e.response.status_code}"
+        logger.error(f"HTTP error from LLM service during audio transcription ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
+        error_detail = f"LLM service returned an HTTP error: {e.response.status_code}"
         try:
-            error_response_data = e.response.json()
+            error_response_data = e.response.json() # Error response from proxy might be JSON
             if "error" in error_response_data and isinstance(error_response_data["error"], dict):
-                 error_detail += f" - {error_response_data['error'].get('message', 'Unknown error from proxy')}"
+                 error_detail += f" - {error_response_data['error'].get('message', 'Unknown error from LLM service')}"
             elif "detail" in error_response_data:
                  error_detail += f" - {error_response_data['detail']}"
             else:
-                 error_detail += f" - {e.response.text}" # Fallback to raw text
-        except json.JSONDecodeError:
-            error_detail += f" - {e.response.text}" # Fallback to raw text if JSON parsing fails
-            
+                 error_detail += f" - {e.response.text[:200]}" # Limit length
+        except json.JSONDecodeError: # If the error response itself is not JSON
+            error_detail += f" - {e.response.text[:200]}"
         raise HTTPException(status_code=e.response.status_code, detail=error_detail)
     except httpx.RequestError as e:
-        logger.error(f"Request error calling LiteLLM proxy transcription endpoint ({e.request.url}): {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to connect to LLM proxy: {e}")
-    except Exception as e:
+        logger.error(f"Request error connecting to LLM service during audio transcription ({e.request.url}): {e}", exc_info=True)
+        raise HTTPException(status_code=503, detail=f"Failed to connect to LLM service: {str(e)}") # 503 Service Unavailable
+    except json.JSONDecodeError as e: # If service returns JSON but it's malformed for AudioTranscriptionResponse
+        logger.error(f"JSON decode error processing response from LLM service for audio transcription: {e.msg}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Invalid JSON response from LLM service: {e.msg}")
+    except Exception as e: # Catch-all for other unexpected errors
         logger.error(f"Unexpected error during audio transcription for model_alias {model_alias}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {str(e)}")
-    finally:
-        # Clean up the temporary file
-        if temp_file_path and temp_file_path.exists():
-            try:
-                # Ensure the file handle is closed before attempting to unlink
-                if 'files' in locals() and 'file' in files:
-                    files['file'][1].close()
-                temp_file_path.unlink()
-                logger.info(f"Temporary audio file {temp_file_path} deleted.")
-            except Exception as e_unlink:
-                logger.error(f"Error deleting temporary audio file {temp_file_path}: {e_unlink}", exc_info=True)
+    # No finally block for temp file cleanup needed anymore
 
 @router.post("/llm/text-to-speech", tags=["LLM Endpoints"])
 async def create_text_to_speech(
@@ -772,85 +714,49 @@ async def create_text_to_speech(
     try:
         logger.info(f"Received text-to-speech request for model_alias: {request_body.model_alias}, voice: {request_body.voice}")
 
-        # Construct the payload for the LiteLLM proxy's /v1/audio/speech endpoint
-        litellm_payload = {
-            "model": request_body.model_alias, # Use the alias as the model name for the proxy
-            "input": request_body.input,
-            "voice": request_body.voice,
-            "response_format": request_body.response_format,
-            "speed": request_body.speed,
-            # Add other parameters as needed
-        }
+        # TextToSpeechRequest doesn't currently have extra_body.
+        # If it needs to support extra_body, it should be added to its Pydantic model.
+        extra_body_payload = getattr(request_body, 'extra_body', None)
+
+        logger.info(f"Calling synthesize_speech_advanced service for model_alias: {request_body.model_alias}")
+
+        audio_stream_generator, media_type = await llm_registry.synthesize_speech_advanced(
+            model_alias=request_body.model_alias,
+            input_text=request_body.input,
+            voice=request_body.voice,
+            response_format=request_body.response_format,
+            speed=request_body.speed,
+            extra_body=extra_body_payload
+            # request_timeout can be passed if desired, using service default for now
+        )
         
-        # Remove None values from the payload
-        litellm_payload = {k: v for k, v in litellm_payload.items() if v is not None}
-
-        logger.info(f"Sending text-to-speech request to LiteLLM proxy: {LITELLM_PROXY_URL}/v1/audio/speech")
-        
-        headers = {}
-        if LITELLM_PROXY_API_KEY:
-            headers["Authorization"] = f"Bearer {LITELLM_PROXY_API_KEY}"
-
-        async with httpx.AsyncClient(timeout=120.0) as client: # Use httpx to call the proxy
-            # Use stream=True to get a streaming response from httpx
-            response = await client.post(
-                f"{LITELLM_PROXY_URL}/v1/audio/speech",
-                json=litellm_payload,
-                headers=headers,
-                stream=True # Enable streaming
-            )
-            response.raise_for_status() # Raise an exception for bad status codes (4xx or 5xx)
-            
-            # Determine media type based on response_format
-            media_type_map = {
-                "mp3": "audio/mpeg",
-                "opus": "audio/opus",
-                "aac": "audio/aac",
-                "flac": "audio/flac",
-                # Add other formats if supported by LiteLLM/providers
-            }
-            media_type = media_type_map.get(request_body.response_format, "application/octet-stream")
-            
-            # Define an async generator function to yield chunks from the httpx stream
-            async def stream_audio_chunks():
-                try:
-                    async for chunk in response.aiter_bytes():
-                        yield chunk
-                except Exception as e_stream:
-                    logger.error(f"Error during TTS audio streaming from proxy: {e_stream}", exc_info=True)
-                    # This error won't be sent to client if headers already sent. Log it.
-                finally:
-                    await response.aclose() # Ensure the httpx response is closed
-
-            # Return a StreamingResponse
-            # The filename for download can be set in Content-Disposition
-            output_filename = f"speech_{int(time.time())}.{request_body.response_format}"
-            return StreamingResponse(
-                stream_audio_chunks(), 
-                media_type=media_type,
-                headers={"Content-Disposition": f"attachment; filename=\"{output_filename}\""}
-            )
+        output_filename = f"speech_{int(time.time())}.{request_body.response_format}"
+        return StreamingResponse(
+            audio_stream_generator,
+            media_type=media_type,
+            headers={"Content-Disposition": f"attachment; filename=\"{output_filename}\""}
+        )
 
     except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error calling LiteLLM proxy text-to-speech endpoint ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
-        error_detail = f"LLM proxy returned an HTTP error: {e.response.status_code}"
+        logger.error(f"HTTP error from LLM service during text-to-speech ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
+        error_detail = f"LLM service returned an HTTP error: {e.response.status_code}"
         try:
+            # TTS errors might not be JSON, but attempt parsing just in case
             error_response_data = e.response.json()
             if "error" in error_response_data and isinstance(error_response_data["error"], dict):
-                 error_detail += f" - {error_response_data['error'].get('message', 'Unknown error from proxy')}"
+                 error_detail += f" - {error_response_data['error'].get('message', 'Unknown error from LLM service')}"
             elif "detail" in error_response_data:
                  error_detail += f" - {error_response_data['detail']}"
             else:
-                 error_detail += f" - {e.response.text}" # Fallback to raw text
+                 error_detail += f" - {e.response.text[:200]}" # Limit length
         except json.JSONDecodeError:
-            error_detail += f" - {e.response.text}" # Fallback to raw text if JSON parsing fails
-            
+            error_detail += f" - {e.response.text[:200]}"
         raise HTTPException(status_code=e.response.status_code, detail=error_detail)
     except httpx.RequestError as e:
-        logger.error(f"Request error calling LiteLLM proxy text-to-speech endpoint ({e.request.url}): {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to connect to LLM proxy: {e}")
-    except Exception as e:
-        logger.error(f"Unexpected error during text-to-speech generation for model_alias {request_body.model_alias}: {e}", exc_info=True)
+        logger.error(f"Request error connecting to LLM service during text-to-speech ({e.request.url}): {e}", exc_info=True)
+        raise HTTPException(status_code=503, detail=f"Failed to connect to LLM service: {str(e)}") # 503 Service Unavailable
+    except Exception as e: # Catch-all for other unexpected errors
+        logger.error(f"Unexpected error during text-to-speech for model_alias {request_body.model_alias}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {str(e)}")
 
 @router.post("/llm/vision-analyze", response_model=ChatCompletionResponse, tags=["LLM Endpoints"]) # Reusing ChatCompletionResponse
@@ -888,65 +794,50 @@ async def create_vision_analysis(
                 # tool_calls are not typically used in direct vision analysis, but ChatMessage supports it
             })
         
-        # Construct the payload for the LiteLLM proxy's /v1/chat/completions endpoint (vision models use this)
-        litellm_payload = {
-            "model": request_body.model_alias, # Use the alias as the model name for the proxy
-            "messages": messages_for_litellm,
-            "max_tokens": request_body.max_tokens,
-            "temperature": request_body.temperature,
-            # user=request_body.user
-            # Add other parameters as needed
-        }
-        
-        # Remove None values from the payload
-        litellm_payload = {k: v for k, v in litellm_payload.items() if v is not None}
+        # VisionAnalysisRequest doesn't currently have extra_body.
+        # If it needs to support extra_body, it should be added to its Pydantic model.
+        extra_body_payload = getattr(request_body, 'extra_body', None)
 
-        logger.info(f"Sending vision analysis request to LiteLLM proxy: {LITELLM_PROXY_URL}/v1/chat/completions")
+        logger.info(f"Calling analyze_vision_advanced service for model_alias: {request_body.model_alias}")
         
-        headers = {}
-        if LITELLM_PROXY_API_KEY:
-            headers["Authorization"] = f"Bearer {LITELLM_PROXY_API_KEY}"
+        service_response_dict = await llm_registry.analyze_vision_advanced(
+            model_alias=request_body.model_alias,
+            messages=messages_for_litellm, # Pass the processed messages
+            max_tokens=request_body.max_tokens,
+            temperature=request_body.temperature,
+            extra_body=extra_body_payload
+            # request_timeout can be passed if desired, using service default for now
+        )
 
-        async with httpx.AsyncClient(timeout=120.0) as client: # Use httpx to call the proxy
-            response = await client.post(
-                f"{LITELLM_PROXY_URL}/v1/chat/completions",
-                json=litellm_payload,
-                headers=headers
-            )
-            response.raise_for_status() # Raise an exception for bad status codes (4xx or 5xx)
-            
-            litellm_response_data = response.json()
-
-        # Map LiteLLM's response structure to our ChatCompletionResponse Pydantic model.
-        # LiteLLM's response should be compatible with OpenAI's ChatCompletionResponse.
-        # We can directly use the Pydantic model's parsing capabilities.
-        
+        # The service_response_dict should contain the 'model' field as returned by LiteLLM.
+        # ChatCompletionResponse Pydantic model will validate this.
         # Ensure the 'model' field in the response is the actual model used by LiteLLM
-        actual_model_used = litellm_response_data.get("model", request_body.model_alias)
-        litellm_response_data['model'] = actual_model_used # Ensure our model uses the actual model ID
-
-        # Use the Pydantic model to parse the response data
-        return ChatCompletionResponse(**litellm_response_data)
+        actual_model_used = service_response_dict.get("model", request_body.model_alias)
+        service_response_dict['model'] = actual_model_used
+        
+        return ChatCompletionResponse(**service_response_dict)
 
     except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP error calling LiteLLM proxy vision endpoint ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
-        error_detail = f"LLM proxy returned an HTTP error: {e.response.status_code}"
+        logger.error(f"HTTP error from LLM service during vision analysis ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
+        error_detail = f"LLM service returned an HTTP error: {e.response.status_code}"
         try:
             error_response_data = e.response.json()
             if "error" in error_response_data and isinstance(error_response_data["error"], dict):
-                 error_detail += f" - {error_response_data['error'].get('message', 'Unknown error from proxy')}"
+                 error_detail += f" - {error_response_data['error'].get('message', 'Unknown error from LLM service')}"
             elif "detail" in error_response_data:
                  error_detail += f" - {error_response_data['detail']}"
             else:
-                 error_detail += f" - {e.response.text}" # Fallback to raw text
+                 error_detail += f" - {e.response.text[:200]}" # Limit length
         except json.JSONDecodeError:
-            error_detail += f" - {e.response.text}" # Fallback to raw text if JSON parsing fails
-            
+            error_detail += f" - {e.response.text[:200]}"
         raise HTTPException(status_code=e.response.status_code, detail=error_detail)
     except httpx.RequestError as e:
-        logger.error(f"Request error calling LiteLLM proxy vision endpoint ({e.request.url}): {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to connect to LLM proxy: {e}")
-    except Exception as e:
+        logger.error(f"Request error connecting to LLM service during vision analysis ({e.request.url}): {e}", exc_info=True)
+        raise HTTPException(status_code=503, detail=f"Failed to connect to LLM service: {str(e)}") # 503 Service Unavailable
+    except json.JSONDecodeError as e: # If service returns non-JSON or ChatCompletionResponse parsing fails
+        logger.error(f"JSON decode error processing response from LLM service for vision analysis: {e.msg}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Invalid JSON response from LLM service: {e.msg}")
+    except Exception as e: # Catch-all for other unexpected errors
         logger.error(f"Unexpected error during vision analysis for model_alias {request_body.model_alias}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"An unexpected error occurred: {str(e)}")
 

--- a/backend/app/tests/routes/test_llm_routes.py
+++ b/backend/app/tests/routes/test_llm_routes.py
@@ -1,0 +1,445 @@
+import asyncio
+import json
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import httpx # For error types and Request object
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+# Adjust imports based on your project structure
+from backend.app.main import app # Assuming your FastAPI app instance is here
+from backend.app.utils.llm_registry_service import LLMRegistryService, get_llm_registry_service
+from backend.app.routes.llm_routes import (
+    ChatCompletionRequest, ChatMessage, ChatCompletionResponse,
+    EmbeddingRequest, EmbeddingResponse,
+    ImageGenerationRequest, ImageGenerationResponse,
+    TextToSpeechRequest,
+    VisionAnalysisRequest,
+    TextCompletionRequest, TextCompletionResponse,
+    AudioTranscriptionResponse # For the transcription endpoint response model
+)
+
+# Helper to consume async generator
+async def consume_async_gen(gen):
+    data = b"" # Assuming bytes for streaming content
+    async for item in gen:
+        data += item
+    return data
+
+async def consume_json_stream_gen(gen):
+    data_chunks = []
+    async for item in gen:
+        data_chunks.append(item)
+    return b"".join(data_chunks)
+
+
+class TestLLMRoutes(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.client = TestClient(app)
+        self.mock_llm_service = MagicMock(spec=LLMRegistryService)
+        # Common data
+        self.model_alias = "test-model-alias"
+
+    def tearDown(self):
+        app.dependency_overrides.clear()
+
+    # --- Tests for /llm/chat (Refactored) ---
+
+    async def test_chat_completions_non_streaming_success(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+        
+        expected_response_data = {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "model": self.model_alias, # Service should return actual model, route ensures it's in response
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Hello there!"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+        }
+        self.mock_llm_service.chat_completion_advanced = AsyncMock(return_value=expected_response_data)
+
+        request_payload = {
+            "model_alias": self.model_alias,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": False,
+            "temperature": 0.5
+        }
+        response = self.client.post("/llm/chat", json=request_payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected_response_data)
+        self.mock_llm_service.chat_completion_advanced.assert_called_once()
+        # Detailed argument checking can be added here if needed
+
+    async def test_chat_completions_streaming_success(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+
+        async def mock_stream_generator():
+            yield b"data: chunk1\n\n"
+            yield b"data: chunk2\n\n"
+            yield b"data: [DONE]\n\n"
+
+        self.mock_llm_service.chat_completion_advanced = AsyncMock(return_value=mock_stream_generator())
+
+        request_payload = {
+            "model_alias": self.model_alias,
+            "messages": [{"role": "user", "content": "Hello stream"}],
+            "stream": True
+        }
+        response = self.client.post("/llm/chat", json=request_payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "text/event-stream; charset=utf-8")
+        
+        stream_content = await consume_json_stream_gen(response.iter_bytes())
+        self.assertEqual(stream_content, b"data: chunk1\n\ndata: chunk2\n\ndata: [DONE]\n\n")
+        self.mock_llm_service.chat_completion_advanced.assert_called_once()
+
+    async def test_chat_completions_service_http_status_error(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+        
+        mock_request = MagicMock(spec=httpx.Request)
+        mock_http_response = MagicMock(spec=httpx.Response)
+        mock_http_response.status_code = 500
+        mock_http_response.text = '{"error": {"message": "proxy server error"}}'
+        mock_http_response.json.return_value = {"error": {"message": "proxy server error"}}
+
+        self.mock_llm_service.chat_completion_advanced = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                message="Server error", request=mock_request, response=mock_http_response
+            )
+        )
+
+        request_payload = {"model_alias": self.model_alias, "messages": [{"role": "user", "content": "Err"}]}
+        response = self.client.post("/llm/chat", json=request_payload)
+
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("proxy server error", response.json()["detail"])
+
+    async def test_chat_completions_service_request_error(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+        mock_request = MagicMock(spec=httpx.Request)
+        self.mock_llm_service.chat_completion_advanced = AsyncMock(
+            side_effect=httpx.RequestError(message="Connection failed", request=mock_request)
+        )
+
+        request_payload = {"model_alias": self.model_alias, "messages": [{"role": "user", "content": "ConnErr"}]}
+        response = self.client.post("/llm/chat", json=request_payload)
+
+        self.assertEqual(response.status_code, 503)
+        self.assertIn("Failed to connect to LLM service", response.json()["detail"])
+        
+    async def test_chat_completions_request_validation_error(self):
+        # No need to mock service here as FastAPI validation happens first
+        request_payload = {"model_alias": self.model_alias} # Missing 'messages'
+        response = self.client.post("/llm/chat", json=request_payload)
+        self.assertEqual(response.status_code, 422) # Unprocessable Entity
+
+    # --- Tests for /llm/embeddings (Refactored) ---
+    async def test_create_embeddings_success(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+        expected_response_data = {
+            "object": "list",
+            "data": [{"object": "embedding", "embedding": [0.1, 0.2, 0.3], "index": 0}],
+            "model": self.model_alias, # Service should return actual model
+            "usage": {"prompt_tokens": 2, "total_tokens": 2}
+        }
+        self.mock_llm_service.create_embeddings_advanced = AsyncMock(return_value=expected_response_data)
+
+        request_payload = {"model_alias": self.model_alias, "input": "Embed this text"}
+        response = self.client.post("/llm/embeddings", json=request_payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected_response_data)
+        self.mock_llm_service.create_embeddings_advanced.assert_called_once_with(
+            model_alias=self.model_alias,
+            input_data="Embed this text",
+            extra_body=None 
+        )
+
+    async def test_create_embeddings_service_http_error(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+        mock_request = MagicMock(spec=httpx.Request)
+        mock_http_response = MagicMock(spec=httpx.Response)
+        mock_http_response.status_code = 401
+        mock_http_response.text = '{"error": "Unauthorized"}'
+        mock_http_response.json.return_value = {"error": "Unauthorized"}
+        self.mock_llm_service.create_embeddings_advanced = AsyncMock(
+            side_effect=httpx.HTTPStatusError("Auth error", request=mock_request, response=mock_http_response)
+        )
+        request_payload = {"model_alias": self.model_alias, "input": "Test input"}
+        response = self.client.post("/llm/embeddings", json=request_payload)
+        self.assertEqual(response.status_code, 401)
+        self.assertIn("Unauthorized", response.json()["detail"])
+
+    async def test_create_embeddings_request_validation_error(self):
+        request_payload = {"model_alias": self.model_alias} # Missing 'input'
+        response = self.client.post("/llm/embeddings", json=request_payload)
+        self.assertEqual(response.status_code, 422)
+
+    # --- Tests for /llm/generate-image (Refactored) ---
+    async def test_generate_image_success(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+        expected_response_data = {
+            "created": int(time.time()),
+            "data": [{"url": "http://example.com/image.png"}]
+        }
+        self.mock_llm_service.generate_image_advanced = AsyncMock(return_value=expected_response_data)
+
+        request_payload = {"model_alias": self.model_alias, "prompt": "A cat"}
+        response = self.client.post("/llm/generate-image", json=request_payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected_response_data)
+        self.mock_llm_service.generate_image_advanced.assert_called_once_with(
+            model_alias=self.model_alias,
+            prompt="A cat",
+            n=1, # Default from Pydantic model
+            size=None, # Default
+            quality=None, # Default
+            style=None, # Default
+            response_format="url", # Default
+            extra_body=None
+        )
+
+    async def test_generate_image_service_http_error(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+        mock_request = MagicMock(spec=httpx.Request)
+        mock_http_response = MagicMock(spec=httpx.Response)
+        mock_http_response.status_code = 400
+        mock_http_response.text = '{"error": "Bad prompt"}'
+        mock_http_response.json.return_value = {"error": "Bad prompt"}
+        self.mock_llm_service.generate_image_advanced = AsyncMock(
+            side_effect=httpx.HTTPStatusError("Bad req", request=mock_request, response=mock_http_response)
+        )
+        request_payload = {"model_alias": self.model_alias, "prompt": "A cat"}
+        response = self.client.post("/llm/generate-image", json=request_payload)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Bad prompt", response.json()["detail"])
+
+    async def test_generate_image_request_validation_error(self):
+        request_payload = {"model_alias": self.model_alias} # Missing 'prompt'
+        response = self.client.post("/llm/generate-image", json=request_payload)
+        self.assertEqual(response.status_code, 422)
+        
+    # --- Tests for /llm/vision-analyze (Refactored) ---
+    async def test_vision_analyze_success(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+        expected_response_data = {
+            "id": "vision-cmpl-123", "object": "chat.completion", "created": 12345,
+            "model": self.model_alias,
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "Image analyzed"}, "finish_reason": "stop"}]
+        }
+        self.mock_llm_service.analyze_vision_advanced = AsyncMock(return_value=expected_response_data)
+        
+        messages = [{"role": "user", "content": [{"type": "text", "text": "Describe"}, {"type": "image_url", "image_url": {"url": "data:..."}}]}]
+        request_payload = {"model_alias": self.model_alias, "messages": messages}
+        response = self.client.post("/llm/vision-analyze", json=request_payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected_response_data)
+        self.mock_llm_service.analyze_vision_advanced.assert_called_once()
+        # Can add more detailed arg checking
+
+    async def test_vision_analyze_service_http_error(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+        mock_request = MagicMock(spec=httpx.Request)
+        mock_http_response = MagicMock(spec=httpx.Response)
+        mock_http_response.status_code = 415 # Unsupported Media Type
+        mock_http_response.text = '{"error": "Bad image format"}'
+        mock_http_response.json.return_value = {"error": "Bad image format"}
+        self.mock_llm_service.analyze_vision_advanced = AsyncMock(
+            side_effect=httpx.HTTPStatusError("Bad image", request=mock_request, response=mock_http_response)
+        )
+        request_payload = {"model_alias": self.model_alias, "messages": [{"role": "user", "content": "..."}]}
+        response = self.client.post("/llm/vision-analyze", json=request_payload)
+        self.assertEqual(response.status_code, 415)
+        self.assertIn("Bad image format", response.json()["detail"])
+        
+    async def test_vision_analyze_request_validation_error(self):
+        request_payload = {"model_alias": self.model_alias} # Missing 'messages'
+        response = self.client.post("/llm/vision-analyze", json=request_payload)
+        self.assertEqual(response.status_code, 422)
+
+    # --- Tests for /llm/text-to-speech (Refactored) ---
+    async def test_text_to_speech_success(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+
+        async def mock_tts_stream_generator():
+            yield b"audio_chunk_1"
+            yield b"audio_chunk_2"
+
+        media_type = "audio/mpeg"
+        self.mock_llm_service.synthesize_speech_advanced = AsyncMock(
+            return_value=(mock_tts_stream_generator(), media_type)
+        )
+
+        request_payload = {"model_alias": self.model_alias, "input": "Speak this", "voice": "alloy"}
+        response = self.client.post("/llm/text-to-speech", json=request_payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], media_type)
+        self.assertTrue("attachment; filename=" in response.headers["content-disposition"])
+        
+        stream_content = await consume_async_gen(response.iter_bytes())
+        self.assertEqual(stream_content, b"audio_chunk_1audio_chunk_2")
+        self.mock_llm_service.synthesize_speech_advanced.assert_called_once()
+
+    async def test_text_to_speech_service_http_error(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+        mock_request = MagicMock(spec=httpx.Request)
+        mock_http_response = MagicMock(spec=httpx.Response)
+        mock_http_response.status_code = 400
+        mock_http_response.text = '{"error": "Invalid voice"}'
+        mock_http_response.json.return_value = {"error": "Invalid voice"}
+        self.mock_llm_service.synthesize_speech_advanced = AsyncMock(
+            side_effect=httpx.HTTPStatusError("Bad voice", request=mock_request, response=mock_http_response)
+        )
+        request_payload = {"model_alias": self.model_alias, "input": "Speak this", "voice": "invalid_voice"}
+        response = self.client.post("/llm/text-to-speech", json=request_payload)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid voice", response.json()["detail"])
+
+    async def test_text_to_speech_request_validation_error(self):
+        request_payload = {"model_alias": self.model_alias, "input": "Speak"} # Missing 'voice'
+        response = self.client.post("/llm/text-to-speech", json=request_payload)
+        self.assertEqual(response.status_code, 422)
+
+    # --- Tests for /llm/transcribe-audio (Refactored) ---
+    async def test_transcribe_audio_json_response_success(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+        expected_response_data = {"text": "This is a transcription."}
+        self.mock_llm_service.transcribe_audio_advanced = AsyncMock(return_value=expected_response_data)
+
+        files = {'file': ('audio.mp3', b'fake_audio_bytes', 'audio/mpeg')}
+        data = {'model_alias': self.model_alias, 'response_format': 'json'}
+        
+        response = self.client.post("/llm/transcribe-audio", files=files, data=data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), expected_response_data)
+        self.mock_llm_service.transcribe_audio_advanced.assert_called_once()
+        # More detailed arg checking for file_data, file_name, content_type etc.
+
+    async def test_transcribe_audio_text_response_success(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+        expected_text_response = "Simple text transcription."
+        self.mock_llm_service.transcribe_audio_advanced = AsyncMock(return_value=expected_text_response)
+
+        files = {'file': ('audio.wav', b'other_fake_bytes', 'audio/wav')}
+        data = {'model_alias': self.model_alias, 'response_format': 'text'}
+
+        response = self.client.post("/llm/transcribe-audio", files=files, data=data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.text, expected_text_response)
+        self.assertEqual(response.headers["content-type"], "text/plain; charset=utf-8")
+
+    async def test_transcribe_audio_service_http_error(self):
+        app.dependency_overrides[get_llm_registry_service] = lambda: self.mock_llm_service
+        mock_request = MagicMock(spec=httpx.Request)
+        mock_http_response = MagicMock(spec=httpx.Response)
+        mock_http_response.status_code = 413 # Payload too large
+        mock_http_response.text = '{"error": "File too large"}'
+        mock_http_response.json.return_value = {"error": "File too large"}
+        self.mock_llm_service.transcribe_audio_advanced = AsyncMock(
+            side_effect=httpx.HTTPStatusError("Too large", request=mock_request, response=mock_http_response)
+        )
+        files = {'file': ('large_audio.mp3', b'large_fake_bytes', 'audio/mpeg')}
+        data = {'model_alias': self.model_alias}
+        response = self.client.post("/llm/transcribe-audio", files=files, data=data)
+        self.assertEqual(response.status_code, 413)
+        self.assertIn("File too large", response.json()["detail"])
+
+    async def test_transcribe_audio_request_validation_error_no_file(self):
+        data = {'model_alias': self.model_alias} # Missing 'file'
+        response = self.client.post("/llm/transcribe-audio", data=data) # No files part
+        self.assertEqual(response.status_code, 422) # FastAPI should catch missing file
+    
+    async def test_transcribe_audio_request_validation_error_no_model(self):
+        files = {'file': ('audio.mp3', b'fake_audio_bytes', 'audio/mpeg')}
+        # Missing 'model_alias' in data
+        response = self.client.post("/llm/transcribe-audio", files=files, data={})
+        self.assertEqual(response.status_code, 422)
+
+
+    # --- Tests for /llm/text-completion (NOT Refactored - uses direct httpx) ---
+    @patch('backend.app.routes.llm_routes.httpx.AsyncClient')
+    async def test_text_completion_non_streaming_success(self, mock_async_client_constructor_direct):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "id": "cmpl-123", "object": "text_completion", "created": 1677652288,
+            "model": self.model_alias,
+            "choices": [{"text": "Generated text", "index": 0, "finish_reason": "length"}]
+        }
+        mock_response.aclose = AsyncMock()
+
+        mock_client_cm = MagicMock()
+        mock_client_cm.post.return_value = mock_response
+        mock_async_client_constructor_direct.return_value.__aenter__.return_value = mock_client_cm
+        mock_async_client_constructor_direct.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        request_payload = {"model_alias": self.model_alias, "prompt": "Complete this:", "stream": False}
+        response = self.client.post("/llm/text-completion", json=request_payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["choices"][0]["text"], "Generated text")
+        # Direct httpx call, so no service method mock to check
+
+    @patch('backend.app.routes.llm_routes.httpx.AsyncClient')
+    async def test_text_completion_streaming_success(self, mock_async_client_constructor_direct_stream):
+        mock_response_stream = MagicMock(spec=httpx.Response)
+        mock_response_stream.status_code = 200
+        mock_response_stream.headers = {"Content-Type": "text/event-stream"}
+        
+        async def mock_aiter_bytes_tc():
+            yield b"data: tc_chunk1\n\n"
+            yield b"data: tc_chunk2\n\n"
+        
+        mock_response_stream.aiter_bytes = mock_aiter_bytes_tc
+        mock_response_stream.aclose = AsyncMock()
+
+        mock_client_cm_stream = MagicMock()
+        mock_client_cm_stream.post.return_value = mock_response_stream
+        mock_async_client_constructor_direct_stream.return_value.__aenter__.return_value = mock_client_cm_stream
+        mock_async_client_constructor_direct_stream.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        request_payload = {"model_alias": self.model_alias, "prompt": "Stream this completion:", "stream": True}
+        response = self.client.post("/llm/text-completion", json=request_payload)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["content-type"], "text/event-stream; charset=utf-8")
+        
+        stream_content = await consume_json_stream_gen(response.iter_bytes())
+        self.assertEqual(stream_content, b"data: tc_chunk1\n\ndata: tc_chunk2\n\n")
+
+    @patch('backend.app.routes.llm_routes.httpx.AsyncClient')
+    async def test_text_completion_direct_http_error(self, mock_async_client_constructor_direct_err):
+        mock_response_error = MagicMock(spec=httpx.Response)
+        mock_response_error.status_code = 500
+        mock_response_error.text = '{"error": "Direct proxy error"}'
+        mock_response_error.request = MagicMock(spec=httpx.Request)
+        mock_response_error.aclose = AsyncMock()
+        mock_response_error.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError("Direct error", request=mock_response_error.request, response=mock_response_error)
+        )
+
+        mock_client_cm_error = MagicMock()
+        mock_client_cm_error.post.return_value = mock_response_error
+        mock_async_client_constructor_direct_err.return_value.__aenter__.return_value = mock_client_cm_error
+        mock_async_client_constructor_direct_err.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        request_payload = {"model_alias": self.model_alias, "prompt": "Error test"}
+        response = self.client.post("/llm/text-completion", json=request_payload)
+        self.assertEqual(response.status_code, 500)
+        self.assertIn("Direct proxy error", response.json()["detail"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/app/tests/utils/__init__.py
+++ b/backend/app/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the directory as a package.

--- a/backend/app/tests/utils/test_llm_registry_service.py
+++ b/backend/app/tests/utils/test_llm_registry_service.py
@@ -1,0 +1,445 @@
+import asyncio
+import json
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import httpx # Import for type hinting and spec for MagicMock
+
+# Assuming LLMRegistryService and config constants are importable
+# Adjust the import path based on your project structure
+from backend.app.utils.llm_registry_service import LLMRegistryService, LITELLM_PROXY_URL, LITELLM_PROXY_API_KEY
+
+# Helper to consume async generator
+async def consume_async_gen(gen):
+    data = []
+    async for item in gen:
+        data.append(item)
+    return data
+
+# Base class for common setup
+class TestLLMRegistryServiceAdvancedMethodsBase(unittest.IsolatedAsyncioTestCase):
+    MOCK_PROXY_URL = "http://mock-litellm-proxy:4000"
+    MOCK_API_KEY = "test-api-key"
+
+    @patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_API_KEY', MOCK_API_KEY)
+    @patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_URL', MOCK_PROXY_URL)
+    async def asyncSetUp(self):
+        # Initialize LLMRegistryService with potentially mocked config
+        # The class LLMRegistryService reads LITELLM_PROXY_URL upon instantiation
+        # and LITELLM_PROXY_API_KEY directly from the module when methods are called.
+        # So, patching them at the module level as above is correct.
+        self.service = LLMRegistryService()
+        self.assertEqual(self.service.litellm_proxy_url, self.MOCK_PROXY_URL)
+        # LITELLM_PROXY_API_KEY is not stored in self.service but used directly by methods.
+
+        # Common mock data
+        self.model_alias = "test-model"
+        self.mock_headers_with_auth = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.MOCK_API_KEY}"
+        }
+        self.mock_headers_without_auth = {"Content-Type": "application/json"}
+
+
+@patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_API_KEY', TestLLMRegistryServiceAdvancedMethodsBase.MOCK_API_KEY)
+@patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_URL', TestLLMRegistryServiceAdvancedMethodsBase.MOCK_PROXY_URL)
+@patch('backend.app.utils.llm_registry_service.httpx.AsyncClient')
+class TestChatCompletionAdvanced(TestLLMRegistryServiceAdvancedMethodsBase):
+
+    async def test_chat_completion_advanced_non_streaming_success(self, mock_async_client_constructor):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "chatcmpl-123", "choices": [{"message": {"content": "Hello"}}]}
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.aclose = AsyncMock() # Mock aclose if it's an async method
+
+        mock_client_cm = MagicMock() # Mock for the client instance within 'async with'
+        mock_client_cm.post.return_value = mock_response
+        mock_async_client_constructor.return_value.__aenter__.return_value = mock_client_cm
+        mock_async_client_constructor.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        messages = [{"role": "user", "content": "Hi"}]
+        response_data = await self.service.chat_completion_advanced(
+            model_alias=self.model_alias, messages=messages, stream=False
+        )
+
+        self.assertEqual(response_data, {"id": "chatcmpl-123", "choices": [{"message": {"content": "Hello"}}]})
+        expected_payload = {"model": self.model_alias, "messages": messages, "stream": False, "temperature": 0.7}
+        mock_client_cm.post.assert_called_once_with(
+            f"{self.MOCK_PROXY_URL}/v1/chat/completions",
+            headers=self.mock_headers_with_auth,
+            json=expected_payload
+        )
+        mock_response.aclose.assert_called_once()
+
+    async def test_chat_completion_advanced_streaming_success(self, mock_async_client_constructor):
+        mock_response_stream = MagicMock(spec=httpx.Response)
+        mock_response_stream.status_code = 200
+        mock_response_stream.headers = {"Content-Type": "text/event-stream"}
+        
+        async def mock_aiter_bytes_func():
+            yield b"data: chunk1\n\n"
+            yield b"data: chunk2\n\n"
+        
+        mock_response_stream.aiter_bytes = mock_aiter_bytes_func
+        mock_response_stream.aclose = AsyncMock()
+
+        mock_client_cm_stream = MagicMock()
+        mock_client_cm_stream.post.return_value = mock_response_stream
+        mock_async_client_constructor.return_value.__aenter__.return_value = mock_client_cm_stream
+        mock_async_client_constructor.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        messages = [{"role": "user", "content": "Stream test"}]
+        stream_gen = await self.service.chat_completion_advanced(
+            model_alias=self.model_alias, messages=messages, stream=True
+        )
+
+        self.assertTrue(hasattr(stream_gen, '__aiter__')) # Check if it's an async generator
+        
+        chunks = await consume_async_gen(stream_gen)
+        self.assertEqual(chunks, [b"data: chunk1\n\n", b"data: chunk2\n\n"])
+        
+        expected_payload = {"model": self.model_alias, "messages": messages, "stream": True, "temperature": 0.7}
+        mock_client_cm_stream.post.assert_called_once_with(
+            f"{self.MOCK_PROXY_URL}/v1/chat/completions",
+            headers=self.mock_headers_with_auth,
+            json=expected_payload
+        )
+        # aclose is called by the stream_generator's finally block in the service
+        self.assertTrue(mock_response_stream.aclose.called)
+
+
+    async def test_chat_completion_advanced_http_status_error(self, mock_async_client_constructor):
+        mock_response_error = MagicMock(spec=httpx.Response)
+        mock_response_error.status_code = 500
+        mock_response_error.text = "Internal Server Error"
+        mock_response_error.request = MagicMock(spec=httpx.Request)
+        mock_response_error.request.url = f"{self.MOCK_PROXY_URL}/v1/chat/completions"
+        mock_response_error.aclose = AsyncMock()
+        mock_response_error.raise_for_status = MagicMock(side_effect=httpx.HTTPStatusError("Error!", request=mock_response_error.request, response=mock_response_error))
+
+
+        mock_client_cm_error = MagicMock()
+        mock_client_cm_error.post.return_value = mock_response_error
+        mock_async_client_constructor.return_value.__aenter__.return_value = mock_client_cm_error
+        mock_async_client_constructor.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        messages = [{"role": "user", "content": "Error test"}]
+        with self.assertRaises(httpx.HTTPStatusError):
+            await self.service.chat_completion_advanced(
+                model_alias=self.model_alias, messages=messages, stream=False
+            )
+        self.assertTrue(mock_response_error.aclose.called)
+
+    async def test_chat_completion_advanced_request_error(self, mock_async_client_constructor):
+        mock_request = MagicMock(spec=httpx.Request)
+        mock_request.url = f"{self.MOCK_PROXY_URL}/v1/chat/completions"
+
+        mock_client_cm_req_error = MagicMock()
+        mock_client_cm_req_error.post.side_effect = httpx.RequestError("Connection failed", request=mock_request)
+        mock_async_client_constructor.return_value.__aenter__.return_value = mock_client_cm_req_error
+        mock_async_client_constructor.return_value.__aexit__ = AsyncMock(return_value=None)
+        
+        messages = [{"role": "user", "content": "Request error test"}]
+        with self.assertRaises(httpx.RequestError):
+            await self.service.chat_completion_advanced(
+                model_alias=self.model_alias, messages=messages, stream=False
+            )
+            
+    async def test_chat_completion_advanced_json_decode_error(self, mock_async_client_constructor):
+        mock_response_json_error = MagicMock(spec=httpx.Response)
+        mock_response_json_error.status_code = 200
+        mock_response_json_error.text = "Not a valid JSON"
+        mock_response_json_error.json.side_effect = json.JSONDecodeError("msg", "doc", 0)
+        mock_response_json_error.aclose = AsyncMock()
+
+        mock_client_cm_json_error = MagicMock()
+        mock_client_cm_json_error.post.return_value = mock_response_json_error
+        mock_async_client_constructor.return_value.__aenter__.return_value = mock_client_cm_json_error
+        mock_async_client_constructor.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        messages = [{"role": "user", "content": "JSON error test"}]
+        with self.assertRaises(json.JSONDecodeError):
+            await self.service.chat_completion_advanced(
+                model_alias=self.model_alias, messages=messages, stream=False
+            )
+        self.assertTrue(mock_response_json_error.aclose.called)
+
+    @patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_API_KEY', None) # Test without API Key
+    async def test_chat_completion_advanced_no_api_key(self, mock_async_client_constructor_no_key, _): # _ for LITELLM_PROXY_URL
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "chatcmpl-123"}
+        mock_response.aclose = AsyncMock()
+
+        mock_client_cm_no_key = MagicMock()
+        mock_client_cm_no_key.post.return_value = mock_response
+        mock_async_client_constructor_no_key.return_value.__aenter__.return_value = mock_client_cm_no_key
+        mock_async_client_constructor_no_key.return_value.__aexit__ = AsyncMock(return_value=None)
+        
+        messages = [{"role": "user", "content": "Hi"}]
+        await self.service.chat_completion_advanced(
+            model_alias=self.model_alias, messages=messages, stream=False, extra_body={"custom": "value"}
+        )
+        expected_payload = {"model": self.model_alias, "messages": messages, "stream": False, "temperature": 0.7, "custom": "value"}
+        mock_client_cm_no_key.post.assert_called_once_with(
+            f"{self.MOCK_PROXY_URL}/v1/chat/completions",
+            headers=self.mock_headers_without_auth, # No Authorization header
+            json=expected_payload
+        )
+
+# Similar test classes would follow for other methods:
+# TestCreateEmbeddingsAdvanced, TestAnalyzeVisionAdvanced, TestSynthesizeSpeechAdvanced,
+# TestTranscribeAudioAdvanced, TestGenerateImageAdvanced
+
+@patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_API_KEY', TestLLMRegistryServiceAdvancedMethodsBase.MOCK_API_KEY)
+@patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_URL', TestLLMRegistryServiceAdvancedMethodsBase.MOCK_PROXY_URL)
+@patch('backend.app.utils.llm_registry_service.httpx.AsyncClient')
+class TestCreateEmbeddingsAdvanced(TestLLMRegistryServiceAdvancedMethodsBase):
+    async def test_create_embeddings_advanced_success(self, mock_async_client_constructor):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"object": "list", "data": [{"embedding": [0.1, 0.2]}]}
+        mock_response.aclose = AsyncMock()
+
+        mock_client_cm = MagicMock()
+        mock_client_cm.post.return_value = mock_response
+        mock_async_client_constructor.return_value.__aenter__.return_value = mock_client_cm
+        mock_async_client_constructor.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        input_data = "Embed this"
+        extra_body = {"encoding_format": "float"}
+        response_data = await self.service.create_embeddings_advanced(
+            model_alias=self.model_alias, input_data=input_data, extra_body=extra_body
+        )
+
+        self.assertEqual(response_data, {"object": "list", "data": [{"embedding": [0.1, 0.2]}]})
+        expected_payload = {"model": self.model_alias, "input": input_data, "encoding_format": "float"}
+        mock_client_cm.post.assert_called_once_with(
+            f"{self.MOCK_PROXY_URL}/v1/embeddings",
+            headers=self.mock_headers_with_auth,
+            json=expected_payload
+        )
+        mock_response.aclose.assert_called_once()
+
+    async def test_create_embeddings_advanced_http_error(self, mock_async_client_constructor):
+        mock_response_error = MagicMock(spec=httpx.Response)
+        mock_response_error.status_code = 400
+        mock_response_error.text = "Bad Request"
+        mock_response_error.request = MagicMock(spec=httpx.Request)
+        mock_response_error.request.url = f"{self.MOCK_PROXY_URL}/v1/embeddings"
+        mock_response_error.aclose = AsyncMock()
+        mock_response_error.raise_for_status = MagicMock(side_effect=httpx.HTTPStatusError("Error!", request=mock_response_error.request, response=mock_response_error))
+
+        mock_client_cm_error = MagicMock()
+        mock_client_cm_error.post.return_value = mock_response_error
+        mock_async_client_constructor.return_value.__aenter__.return_value = mock_client_cm_error
+        mock_async_client_constructor.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        with self.assertRaises(httpx.HTTPStatusError):
+            await self.service.create_embeddings_advanced(model_alias=self.model_alias, input_data="test")
+        self.assertTrue(mock_response_error.aclose.called)
+
+@patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_API_KEY', TestLLMRegistryServiceAdvancedMethodsBase.MOCK_API_KEY)
+@patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_URL', TestLLMRegistryServiceAdvancedMethodsBase.MOCK_PROXY_URL)
+@patch('backend.app.utils.llm_registry_service.httpx.AsyncClient')
+class TestAnalyzeVisionAdvanced(TestLLMRegistryServiceAdvancedMethodsBase):
+    async def test_analyze_vision_advanced_success(self, mock_async_client_constructor):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"choices": [{"message": {"content": "Image description"}}]}
+        mock_response.aclose = AsyncMock()
+
+        mock_client_cm = MagicMock()
+        mock_client_cm.post.return_value = mock_response
+        mock_async_client_constructor.return_value.__aenter__.return_value = mock_client_cm
+        mock_async_client_constructor.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        messages = [{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "data:..."}}]}]
+        extra_body = {"custom_param": "vision_value"}
+        response_data = await self.service.analyze_vision_advanced(
+            model_alias=self.model_alias, messages=messages, max_tokens=150, extra_body=extra_body
+        )
+
+        self.assertEqual(response_data, {"choices": [{"message": {"content": "Image description"}}]})
+        expected_payload = {"model": self.model_alias, "messages": messages, "max_tokens": 150, "custom_param": "vision_value"}
+        mock_client_cm.post.assert_called_once_with(
+            f"{self.MOCK_PROXY_URL}/v1/chat/completions", # Vision uses chat completions
+            headers=self.mock_headers_with_auth,
+            json=expected_payload
+        )
+        mock_response.aclose.assert_called_once()
+
+@patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_API_KEY', TestLLMRegistryServiceAdvancedMethodsBase.MOCK_API_KEY)
+@patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_URL', TestLLMRegistryServiceAdvancedMethodsBase.MOCK_PROXY_URL)
+@patch('backend.app.utils.llm_registry_service.httpx.AsyncClient')
+class TestSynthesizeSpeechAdvanced(TestLLMRegistryServiceAdvancedMethodsBase):
+    async def test_synthesize_speech_advanced_success(self, mock_async_client_constructor):
+        mock_response_stream = MagicMock(spec=httpx.Response)
+        mock_response_stream.status_code = 200
+        mock_response_stream.headers = {"Content-Type": "audio/mpeg"} # Default for mp3
+        
+        async def mock_aiter_bytes_tts():
+            yield b"tts_chunk1"
+            yield b"tts_chunk2"
+        
+        mock_response_stream.aiter_bytes = mock_aiter_bytes_tts
+        mock_response_stream.aclose = AsyncMock() # Mock aclose for the response
+
+        mock_client_cm_tts = MagicMock() # Mock for the client instance
+        mock_client_cm_tts.post.return_value = mock_response_stream
+        
+        # The AsyncClient itself needs its __aexit__ mocked for when it's closed by stream_generator
+        mock_async_client_instance = MagicMock()
+        mock_async_client_instance.__aenter__.return_value = mock_client_cm_tts
+        mock_async_client_instance.__aexit__ = AsyncMock(return_value=None)
+        mock_async_client_constructor.return_value = mock_async_client_instance
+
+
+        input_text = "Hello world"
+        voice = "alloy"
+        response_format = "mp3"
+        
+        stream_gen, media_type = await self.service.synthesize_speech_advanced(
+            model_alias=self.model_alias, input_text=input_text, voice=voice, response_format=response_format
+        )
+
+        self.assertEqual(media_type, "audio/mpeg")
+        self.assertTrue(hasattr(stream_gen, '__aiter__'))
+        
+        chunks = await consume_async_gen(stream_gen)
+        self.assertEqual(chunks, [b"tts_chunk1", b"tts_chunk2"])
+        
+        expected_payload = {
+            "model": self.model_alias, "input": input_text, "voice": voice, 
+            "response_format": response_format, "speed": 1.0
+        }
+        mock_client_cm_tts.post.assert_called_once_with(
+            f"{self.MOCK_PROXY_URL}/v1/audio/speech",
+            headers=self.mock_headers_with_auth,
+            json=expected_payload
+        )
+        # aclose for response and client are called by the stream_generator's finally block
+        self.assertTrue(mock_response_stream.aclose.called)
+        self.assertTrue(mock_async_client_instance.__aexit__.called)
+
+
+    async def test_synthesize_speech_advanced_http_error_before_stream(self, mock_async_client_constructor):
+        mock_response_error = MagicMock(spec=httpx.Response)
+        mock_response_error.status_code = 503
+        mock_response_error.text = "Service Unavailable"
+        mock_response_error.request = MagicMock(spec=httpx.Request)
+        mock_response_error.request.url = f"{self.MOCK_PROXY_URL}/v1/audio/speech"
+        mock_response_error.aclose = AsyncMock()
+        mock_response_error.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError("Error!", request=mock_response_error.request, response=mock_response_error)
+        )
+
+        mock_client_cm_error = MagicMock()
+        mock_client_cm_error.post.return_value = mock_response_error
+        
+        mock_async_client_instance_err = MagicMock()
+        mock_async_client_instance_err.__aenter__.return_value = mock_client_cm_error
+        mock_async_client_instance_err.__aexit__ = AsyncMock(return_value=None)
+        mock_async_client_constructor.return_value = mock_async_client_instance_err
+
+        with self.assertRaises(httpx.HTTPStatusError):
+            await self.service.synthesize_speech_advanced(
+                model_alias=self.model_alias, input_text="test", voice="echo"
+            )
+        self.assertTrue(mock_response_error.aclose.called)
+        self.assertTrue(mock_async_client_instance_err.__aexit__.called)
+
+
+@patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_API_KEY', TestLLMRegistryServiceAdvancedMethodsBase.MOCK_API_KEY)
+@patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_URL', TestLLMRegistryServiceAdvancedMethodsBase.MOCK_PROXY_URL)
+@patch('backend.app.utils.llm_registry_service.httpx.AsyncClient')
+class TestTranscribeAudioAdvanced(TestLLMRegistryServiceAdvancedMethodsBase):
+    async def test_transcribe_audio_advanced_json_response(self, mock_async_client_constructor):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "application/json"}
+        mock_response.json.return_value = {"text": "Transcription result"}
+        mock_response.aclose = AsyncMock()
+
+        mock_client_cm = MagicMock()
+        mock_client_cm.post.return_value = mock_response
+        mock_async_client_constructor.return_value.__aenter__.return_value = mock_client_cm
+        mock_async_client_constructor.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        file_data = b"audio_bytes"
+        file_name = "audio.mp3"
+        content_type = "audio/mpeg"
+        
+        response_data = await self.service.transcribe_audio_advanced(
+            model_alias=self.model_alias, file_name=file_name, file_data=file_data, 
+            content_type=content_type, response_format="json"
+        )
+
+        self.assertEqual(response_data, {"text": "Transcription result"})
+        expected_data_payload = {
+            "model": self.model_alias, "response_format": "json", "temperature": 0.0
+        }
+        expected_files_payload = {'file': (file_name, file_data, content_type)}
+        
+        mock_client_cm.post.assert_called_once_with(
+            f"{self.MOCK_PROXY_URL}/v1/audio/transcriptions",
+            headers={"Authorization": f"Bearer {self.MOCK_API_KEY}"}, # httpx sets Content-Type for multipart
+            data=expected_data_payload,
+            files=expected_files_payload
+        )
+        mock_response.aclose.assert_called_once()
+
+    async def test_transcribe_audio_advanced_text_response(self, mock_async_client_constructor):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {"Content-Type": "text/plain"}
+        mock_response.text = "Simple text transcription"
+        mock_response.aclose = AsyncMock()
+
+        mock_client_cm = MagicMock()
+        mock_client_cm.post.return_value = mock_response
+        mock_async_client_constructor.return_value.__aenter__.return_value = mock_client_cm
+        mock_async_client_constructor.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        response_data = await self.service.transcribe_audio_advanced(
+            model_alias=self.model_alias, file_name="a.wav", file_data=b"...", 
+            content_type="audio/wav", response_format="text"
+        )
+        self.assertEqual(response_data, "Simple text transcription")
+
+
+@patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_API_KEY', TestLLMRegistryServiceAdvancedMethodsBase.MOCK_API_KEY)
+@patch('backend.app.utils.llm_registry_service.LITELLM_PROXY_URL', TestLLMRegistryServiceAdvancedMethodsBase.MOCK_PROXY_URL)
+@patch('backend.app.utils.llm_registry_service.httpx.AsyncClient')
+class TestGenerateImageAdvanced(TestLLMRegistryServiceAdvancedMethodsBase):
+    async def test_generate_image_advanced_success(self, mock_async_client_constructor):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"created": 123, "data": [{"url": "http://image.url"}]}
+        mock_response.aclose = AsyncMock()
+
+        mock_client_cm = MagicMock()
+        mock_client_cm.post.return_value = mock_response
+        mock_async_client_constructor.return_value.__aenter__.return_value = mock_client_cm
+        mock_async_client_constructor.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        prompt = "A cat playing piano"
+        response_data = await self.service.generate_image_advanced(
+            model_alias=self.model_alias, prompt=prompt, n=1, size="1024x1024"
+        )
+
+        self.assertEqual(response_data, {"created": 123, "data": [{"url": "http://image.url"}]})
+        expected_payload = {
+            "model": self.model_alias, "prompt": prompt, "n": 1, 
+            "size": "1024x1024", "response_format": "url"
+        }
+        mock_client_cm.post.assert_called_once_with(
+            f"{self.MOCK_PROXY_URL}/v1/images/generations",
+            headers=self.mock_headers_with_auth,
+            json=expected_payload
+        )
+        mock_response.aclose.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/app/utils/llm_registry_service.py
+++ b/backend/app/utils/llm_registry_service.py
@@ -312,127 +312,701 @@ class LLMRegistryService:
             "cache_ttl_seconds": LLM_CACHE_TTL_SECONDS
         }
 
-    async def transcribe_audio(self, model_id: str, audio_data: bytes, **kwargs) -> Optional[Dict[str, Any]]:
+    # Old transcribe_audio method removed.
+    # Old get_chat_completion method removed.
+
+    async def chat_completion_advanced(
+        self,
+        model_alias: str,
+        messages: List[Dict[str, Any]],
+        temperature: Optional[float] = 0.7,
+        max_tokens: Optional[int] = None,
+        stream: Optional[bool] = False,
+        user: Optional[str] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
+        safety_settings: Optional[List[Dict[str, Any]]] = None,
+        thinking: Optional[Dict[str, Any]] = None,
+        reasoning_effort: Optional[str] = None,
+        cache_control: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
+        request_timeout: Optional[float] = 120.0
+    ) -> Union[Dict[str, Any], AsyncGenerator[bytes, None]]:
         """
-        Sends audio data to the LiteLLM proxy for transcription.
+        Performs a chat completion request to the LiteLLM proxy with advanced parameters.
 
         Args:
-            model_id: The ID of the transcription model to use (as configured in LiteLLM).
-            audio_data: The audio content as bytes.
-            **kwargs: Additional parameters to pass to the LiteLLM transcription endpoint.
+            model_alias: The alias of the model to use (as configured in LiteLLM).
+            messages: A list of message objects.
+            temperature: Sampling temperature.
+            max_tokens: Maximum number of tokens to generate.
+            stream: Whether to stream the response.
+            user: A unique identifier for the end-user.
+            tools: A list of tools the model may call.
+            tool_choice: Controls which tool the model should use.
+            safety_settings: Safety settings for the request.
+            thinking: Custom parameter for LiteLLM.
+            reasoning_effort: Custom parameter for LiteLLM.
+            cache_control: Cache control parameters for LiteLLM proxy.
+            extra_body: Additional parameters to include in the request body.
+            request_timeout: Timeout for the HTTP request in seconds.
 
         Returns:
-            A dictionary containing the transcription results (full text and segments)
-            or None if the transcription fails.
+            If stream is False, a dictionary containing the chat completion response.
+            If stream is True, an async generator yielding bytes of the streamed response.
+        
+        Raises:
+            ValueError: If LiteLLM Proxy URL is not configured.
+            httpx.HTTPStatusError: If the proxy returns an HTTP error status.
+            httpx.RequestError: If a network error occurs.
+            json.JSONDecodeError: If stream is False and the response is not valid JSON.
         """
-        endpoint_url = f"{self.litellm_proxy_url}/v1/audio/transcriptions" # Use instance's URL
-        logger.info(f"Attempting transcription via LiteLLM proxy: {endpoint_url} with model '{model_id}'")
+        proxy_url_to_use = self.litellm_proxy_url if self.litellm_proxy_url else LITELLM_PROXY_URL
+        if not proxy_url_to_use:
+            logger.error("LiteLLM Proxy URL is not configured for chat_completion_advanced.")
+            raise ValueError("LiteLLM Proxy URL is not configured.")
 
-        headers = {}
+        endpoint_url = f"{proxy_url_to_use}/v1/chat/completions"
+        logger.info(f"Attempting advanced chat completion: {endpoint_url} with model '{model_alias}', stream: {stream}")
+
+        headers = {"Content-Type": "application/json"}
+        # Use the global LITELLM_PROXY_API_KEY as the class doesn't store it per instance
+        # This aligns with how _fetch_models_from_litellm_proxy and transcribe_audio use it.
         if LITELLM_PROXY_API_KEY:
             headers["Authorization"] = f"Bearer {LITELLM_PROXY_API_KEY}"
 
-        # LiteLLM expects the audio file as a multipart/form-data file upload
-        # and the model ID as a form field.
-        files = {'file': ('audio.mp3', audio_data, 'audio/mpeg')} # Assuming mp3 format is acceptable or handled by proxy
-        data = {'model': model_id}
+        litellm_payload = {
+            "model": model_alias,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "stream": stream,
+            "user": user,
+            "tools": tools,
+            "tool_choice": tool_choice,
+            "safety_settings": safety_settings,
+            "thinking": thinking,
+            "reasoning_effort": reasoning_effort,
+            "cache_control": cache_control,
+            # "extra_body" is merged below if it exists
+        }
 
-        # Include any additional kwargs as form data
-        for key, value in kwargs.items():
-            data[key] = value
+        # Merge extra_body if provided
+        if extra_body:
+            litellm_payload.update(extra_body)
+        
+        # Remove None values from the payload to avoid sending them to LiteLLM
+        litellm_payload = {k: v for k, v in litellm_payload.items() if v is not None}
+        
+        logger.debug(f"LiteLLM payload for advanced chat completion (model: {model_alias}): {litellm_payload}")
 
-        try:
-            async with httpx.AsyncClient(timeout=600.0) as client: # Increased timeout for transcription
-                response = await client.post(endpoint_url, headers=headers, files=files, data=data)
-                response.raise_for_status() # Raise an exception for bad status codes
+        async with httpx.AsyncClient(timeout=request_timeout) as client:
+            response = None # Initialize response to None for broader scope in finally blocks
+            try:
+                response = await client.post(
+                    endpoint_url,
+                    headers=headers,
+                    json=litellm_payload
+                )
+                response.raise_for_status() # Raise HTTPStatusError for 4xx/5xx responses
 
-                transcription_result = response.json()
-                logger.info(f"Transcription successful for model '{model_id}'.")
-
-                # LiteLLM's /v1/audio/transcriptions endpoint (OpenAI compatible)
-                # returns a structure like: {"text": "...", "segments": [...]}
-                # We need to return this structure or adapt it if necessary for transcribe1.py
-
-                # Ensure the response has the expected keys
-                if "text" in transcription_result and "segments" in transcription_result:
-                     return transcription_result
+                if stream:
+                    async def stream_generator():
+                        # Ensure response is available in this inner scope
+                        nonlocal response 
+                        try:
+                            async for chunk in response.aiter_bytes():
+                                yield chunk
+                        except Exception as e_stream: 
+                            logger.error(f"Error during response streaming for model '{model_alias}': {e_stream}", exc_info=True)
+                            raise 
+                        finally:
+                            if response:
+                                await response.aclose()
+                                logger.debug(f"Stream closed for model '{model_alias}'")
+                    return stream_generator()
                 else:
-                     logger.error(f"Unexpected response structure from LiteLLM transcription endpoint: {transcription_result}")
-                     return None
+                    try:
+                        response_data = response.json()
+                    except json.JSONDecodeError as e_json:
+                        logger.error(f"JSON decode error for non-streamed response from model '{model_alias}': {e_json.msg}. Response text (first 500 chars): {response.text[:500]}", exc_info=False)
+                        # Response will be closed in the outer finally block
+                        raise 
+                    
+                    logger.info(f"Non-streamed chat completion successful for model '{model_alias}'.")
+                    return response_data
 
-        except httpx.HTTPStatusError as e:
-            logger.error(f"HTTP error during transcription via LiteLLM proxy ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
-            return None
-        except httpx.RequestError as e:
-            logger.error(f"Request error during transcription via LiteLLM proxy ({e.request.url}): {e}", exc_info=True)
-            return None
-        except Exception as e:
-            logger.error(f"Unexpected error during transcription via LiteLLM proxy: {e}", exc_info=True)
-            return None
+            except httpx.HTTPStatusError as e_http:
+                response_text = e_http.response.text[:500] if e_http.response else "No response body"
+                logger.error(
+                    f"HTTP error during advanced chat completion for model '{model_alias}' ({e_http.request.url}): "
+                    f"{e_http.response.status_code} - {response_text}", 
+                    exc_info=True # Full traceback for HTTPStatusError
+                )
+                raise 
+            except httpx.RequestError as e_req:
+                logger.error(
+                    f"Request error during advanced chat completion for model '{model_alias}' ({e_req.request.url}): {e_req}", 
+                    exc_info=True
+                )
+                raise 
+            except Exception as e_unexpected:
+                logger.error(
+                    f"Unexpected error during advanced chat completion for model '{model_alias}': {e_unexpected}",
+                    exc_info=True
+                )
+                raise
+            finally:
+                if response and not stream: # For non-streaming, response should be closed here if not already
+                    if hasattr(response, 'is_closed') and not response.is_closed:
+                        await response.aclose()
+                        logger.debug(f"Non-streamed response closed for model '{model_alias}' in finally block.")
+                    elif not hasattr(response, 'is_closed'): # If it's not an httpx.Response (e.g. error before response)
+                        pass
+                # For streaming, stream_generator's finally block handles closing.
 
-    async def get_chat_completion(self, model_id: str, messages: list, **kwargs) -> Optional[str]:
+    async def create_embeddings_advanced(
+        self,
+        model_alias: str,
+        input_data: Union[str, List[str]],
+        extra_body: Optional[Dict[str, Any]] = None,
+        request_timeout: Optional[float] = 60.0
+    ) -> Dict[str, Any]:
         """
-        Gets a chat completion from the LiteLLM proxy.
+        Creates embeddings for the given input using the specified model via LiteLLM proxy.
 
         Args:
-            model_id: The ID of the chat model to use (as configured in LiteLLM).
-            messages: A list of message objects (e.g., [{"role": "user", "content": "Hello"}]).
-            **kwargs: Additional parameters for the chat completion request (e.g., temperature, max_tokens).
+            model_alias: The alias of the embedding model to use (as configured in LiteLLM).
+            input_data: A string or list of strings to embed.
+            extra_body: Additional parameters to include in the request body,
+                        e.g., {"encoding_format": "base64", "user": "user-123"}.
+            request_timeout: Timeout for the HTTP request in seconds.
 
         Returns:
-            The content of the first choice's message as a string, or None if an error occurs.
+            A dictionary representing the embedding response from LiteLLM,
+            typically mappable to OpenAI's EmbeddingResponse schema.
+        
+        Raises:
+            ValueError: If LiteLLM Proxy URL is not configured.
+            httpx.HTTPStatusError: If the proxy returns an HTTP error status.
+            httpx.RequestError: If a network error occurs.
+            json.JSONDecodeError: If the response is not valid JSON.
         """
-        endpoint_url = f"{self.litellm_proxy_url}/v1/chat/completions" # Use instance's URL
-        logger.info(f"Attempting chat completion via LiteLLM proxy: {endpoint_url} with model '{model_id}'")
+        proxy_url_to_use = self.litellm_proxy_url if self.litellm_proxy_url else LITELLM_PROXY_URL
+        if not proxy_url_to_use:
+            logger.error("LiteLLM Proxy URL is not configured for create_embeddings_advanced.")
+            raise ValueError("LiteLLM Proxy URL is not configured.")
+
+        endpoint_url = f"{proxy_url_to_use}/v1/embeddings"
+        logger.info(f"Attempting to create embeddings: {endpoint_url} with model '{model_alias}'")
 
         headers = {"Content-Type": "application/json"}
-        if LITELLM_PROXY_API_KEY: # Use the global API key from app_config for now
+        if LITELLM_PROXY_API_KEY:
             headers["Authorization"] = f"Bearer {LITELLM_PROXY_API_KEY}"
 
-        payload = {
-            "model": model_id,
-            "messages": messages,
-            **kwargs
+        litellm_payload = {
+            "model": model_alias,
+            "input": input_data,
         }
-        
-        # Default stream to False if not provided, as this method expects a single response
-        if "stream" not in payload:
-            payload["stream"] = False
 
-        try:
-            async with httpx.AsyncClient(timeout=kwargs.get("request_timeout", 120.0)) as client: # Allow timeout override
-                response = await client.post(endpoint_url, headers=headers, json=payload)
+        if extra_body:
+            litellm_payload.update(extra_body)
+        
+        # Remove None values from the payload to keep it clean
+        litellm_payload = {k: v for k, v in litellm_payload.items() if v is not None}
+
+        logger.debug(f"LiteLLM payload for embeddings (model: {model_alias}): {litellm_payload}")
+
+        async with httpx.AsyncClient(timeout=request_timeout) as client:
+            response = None 
+            try:
+                response = await client.post(
+                    endpoint_url,
+                    headers=headers,
+                    json=litellm_payload
+                )
+                response.raise_for_status() 
+                
+                try:
+                    response_data = response.json()
+                except json.JSONDecodeError as e_json:
+                    logger.error(f"JSON decode error for embeddings response from model '{model_alias}': {e_json.msg}. Response text (first 500 chars): {response.text[:500]}", exc_info=False)
+                    raise
+                
+                logger.info(f"Embeddings creation successful for model '{model_alias}'.")
+                return response_data
+
+            except httpx.HTTPStatusError as e_http:
+                response_text = e_http.response.text[:500] if e_http.response else "No response body"
+                logger.error(
+                    f"HTTP error during embeddings creation for model '{model_alias}' ({e_http.request.url}): "
+                    f"{e_http.response.status_code} - {response_text}", 
+                    exc_info=True
+                )
+                raise
+            except httpx.RequestError as e_req:
+                logger.error(
+                    f"Request error during embeddings creation for model '{model_alias}' ({e_req.request.url}): {e_req}", 
+                    exc_info=True
+                )
+                raise
+            except Exception as e_unexpected: # Catch any other unexpected errors
+                logger.error(
+                    f"Unexpected error during embeddings creation for model '{model_alias}': {e_unexpected}",
+                    exc_info=True
+                )
+                raise
+            finally:
+                if response:
+                    await response.aclose()
+                    logger.debug(f"Embeddings response closed for model '{model_alias}' in finally block.")
+
+    async def analyze_vision_advanced(
+        self,
+        model_alias: str,
+        messages: List[Dict[str, Any]], # Already converted from Pydantic ChatMessage with vision content
+        max_tokens: Optional[int] = 300,
+        temperature: Optional[float] = None,
+        # user: Optional[str] = None, # Not in current llm_routes.py payload for vision
+        extra_body: Optional[Dict[str, Any]] = None,
+        request_timeout: Optional[float] = 120.0
+    ) -> Dict[str, Any]: # Returns dict mappable to ChatCompletionResponse
+        """
+        Sends a request with vision (image) data to the LiteLLM proxy.
+        Assumes messages are already formatted correctly for multimodal input.
+
+        Args:
+            model_alias: The alias of the vision model to use.
+            messages: A list of message objects, with image URLs formatted as per LiteLLM expectations
+                      (e.g., {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}).
+            max_tokens: Maximum number of tokens to generate in the response.
+            temperature: Sampling temperature.
+            extra_body: Additional parameters to include in the request body.
+            request_timeout: Timeout for the HTTP request in seconds.
+
+        Returns:
+            A dictionary representing the chat completion response from LiteLLM.
+        
+        Raises:
+            ValueError: If LiteLLM Proxy URL is not configured.
+            httpx.HTTPStatusError: If the proxy returns an HTTP error status.
+            httpx.RequestError: If a network error occurs.
+            json.JSONDecodeError: If the response is not valid JSON.
+        """
+        proxy_url_to_use = self.litellm_proxy_url if self.litellm_proxy_url else LITELLM_PROXY_URL
+        if not proxy_url_to_use:
+            logger.error("LiteLLM Proxy URL is not configured for analyze_vision_advanced.")
+            raise ValueError("LiteLLM Proxy URL is not configured.")
+
+        endpoint_url = f"{proxy_url_to_use}/v1/chat/completions" # Vision models often use chat completions endpoint
+        logger.info(f"Attempting vision analysis: {endpoint_url} with model '{model_alias}'")
+
+        headers = {"Content-Type": "application/json"}
+        if LITELLM_PROXY_API_KEY:
+            headers["Authorization"] = f"Bearer {LITELLM_PROXY_API_KEY}"
+
+        litellm_payload = {
+            "model": model_alias,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+        }
+
+        if extra_body:
+            litellm_payload.update(extra_body)
+        
+        # Remove None values from the payload
+        litellm_payload = {k: v for k, v in litellm_payload.items() if v is not None}
+
+        logger.debug(f"LiteLLM payload for vision analysis (model: {model_alias}): {litellm_payload}")
+
+        async with httpx.AsyncClient(timeout=request_timeout) as client:
+            response = None
+            try:
+                response = await client.post(
+                    endpoint_url,
+                    headers=headers,
+                    json=litellm_payload
+                )
                 response.raise_for_status()
                 
-                completion_data = response.json()
+                try:
+                    response_data = response.json()
+                except json.JSONDecodeError as e_json:
+                    logger.error(f"JSON decode error for vision analysis response from model '{model_alias}': {e_json.msg}. Response text (first 500 chars): {response.text[:500]}", exc_info=False)
+                    raise
                 
-                if completion_data.get("choices") and isinstance(completion_data["choices"], list) and len(completion_data["choices"]) > 0:
-                    first_choice = completion_data["choices"][0]
-                    if first_choice.get("message") and isinstance(first_choice["message"], dict):
-                        content = first_choice["message"].get("content")
-                        if content:
-                            logger.info(f"Chat completion successful for model '{model_id}'.")
-                            return str(content)
-                        else:
-                            logger.warning(f"Chat completion response for model '{model_id}' had no content in the first choice's message.")
-                    else:
-                        logger.warning(f"Chat completion response for model '{model_id}' had no 'message' object in the first choice.")
-                else:
-                    logger.warning(f"Chat completion response for model '{model_id}' had no 'choices' or choices were empty.")
-                
-                return None # Fallthrough if expected data not found
+                logger.info(f"Vision analysis successful for model '{model_alias}'.")
+                return response_data
 
-        except httpx.HTTPStatusError as e:
-            logger.error(f"HTTP error during chat completion ({e.request.url}): {e.response.status_code} - {e.response.text}", exc_info=True)
-        except httpx.RequestError as e:
-            logger.error(f"Request error during chat completion ({e.request.url}): {e}", exc_info=True)
-        except json.JSONDecodeError as e:
-            logger.error(f"JSON decode error parsing chat completion response: {e.msg}. Response text: {e.doc}", exc_info=False)
-        except Exception as e:
-            logger.error(f"Unexpected error during chat completion: {e}", exc_info=True)
+            except httpx.HTTPStatusError as e_http:
+                response_text = e_http.response.text[:500] if e_http.response else "No response body"
+                logger.error(
+                    f"HTTP error during vision analysis for model '{model_alias}' ({e_http.request.url}): "
+                    f"{e_http.response.status_code} - {response_text}", 
+                    exc_info=True
+                )
+                raise
+            except httpx.RequestError as e_req:
+                logger.error(
+                    f"Request error during vision analysis for model '{model_alias}' ({e_req.request.url}): {e_req}", 
+                    exc_info=True
+                )
+                raise
+            except Exception as e_unexpected:
+                logger.error(
+                    f"Unexpected error during vision analysis for model '{model_alias}': {e_unexpected}",
+                    exc_info=True
+                )
+                raise
+            finally:
+                if response:
+                    await response.aclose()
+                    logger.debug(f"Vision analysis response closed for model '{model_alias}' in finally block.")
+
+    async def synthesize_speech_advanced(
+        self,
+        model_alias: str,
+        input_text: str,
+        voice: str,
+        response_format: Optional[str] = "mp3",
+        speed: Optional[float] = 1.0,
+        extra_body: Optional[Dict[str, Any]] = None,
+        request_timeout: Optional[float] = 120.0
+    ) -> Tuple[AsyncGenerator[bytes, None], str]:
+        """
+        Synthesizes speech from text using the specified model via LiteLLM proxy,
+        returning a stream of audio data and its media type.
+
+        Args:
+            model_alias: The alias of the TTS model to use.
+            input_text: The text to synthesize.
+            voice: The voice to use for synthesis.
+            response_format: The desired audio format (e.g., "mp3", "opus").
+            speed: The speed of the speech.
+            extra_body: Additional parameters for the LiteLLM request.
+            request_timeout: Timeout for the HTTP request.
+
+        Returns:
+            A tuple containing:
+                - An async generator yielding bytes of the audio stream.
+                - A string representing the media type of the audio (e.g., "audio/mpeg").
         
-        return None
+        Raises:
+            ValueError: If LiteLLM Proxy URL is not configured.
+            httpx.HTTPStatusError: If the proxy returns an HTTP error status on the initial request.
+            httpx.RequestError: If a network error occurs on the initial request.
+        """
+        proxy_url_to_use = self.litellm_proxy_url if self.litellm_proxy_url else LITELLM_PROXY_URL
+        if not proxy_url_to_use:
+            logger.error("LiteLLM Proxy URL is not configured for synthesize_speech_advanced.")
+            raise ValueError("LiteLLM Proxy URL is not configured.")
 
+        endpoint_url = f"{proxy_url_to_use}/v1/audio/speech"
+        logger.info(f"Attempting speech synthesis: {endpoint_url} with model '{model_alias}', format: {response_format}")
+
+        headers = {"Content-Type": "application/json"} # LiteLLM /v1/audio/speech usually expects JSON
+        if LITELLM_PROXY_API_KEY:
+            headers["Authorization"] = f"Bearer {LITELLM_PROXY_API_KEY}"
+
+        litellm_payload = {
+            "model": model_alias,
+            "input": input_text,
+            "voice": voice,
+            "response_format": response_format,
+            "speed": speed,
+        }
+
+        if extra_body:
+            litellm_payload.update(extra_body)
+        
+        litellm_payload = {k: v for k, v in litellm_payload.items() if v is not None}
+        logger.debug(f"LiteLLM payload for speech synthesis (model: {model_alias}): {litellm_payload}")
+
+        media_type_map = {
+            "mp3": "audio/mpeg",
+            "opus": "audio/opus",
+            "aac": "audio/aac",
+            "flac": "audio/flac",
+            # Add others if LiteLLM supports them, e.g., pcm, wav
+            "pcm": "audio/wav", # Often PCM is delivered as WAV
+            "wav": "audio/wav"
+        }
+        media_type = media_type_map.get(response_format.lower() if response_format else "mp3", "application/octet-stream")
+
+        # httpx.AsyncClient should be managed carefully with response streaming
+        # The response object itself needs to be passed to the generator
+        
+        client = httpx.AsyncClient(timeout=request_timeout)
+        response = None # Define response here to ensure it's available in finally block
+        try:
+            response = await client.post(
+                endpoint_url,
+                headers=headers,
+                json=litellm_payload
+            )
+            response.raise_for_status() # Check for errors before starting to stream
+
+            # If successful up to here, prepare the generator
+            async def stream_generator(r: httpx.Response, c: httpx.AsyncClient):
+                try:
+                    async for chunk in r.aiter_bytes():
+                        yield chunk
+                except httpx.ReadError as e_read: # Catch errors during streaming
+                    logger.error(f"Read error during speech audio streaming for model '{model_alias}': {e_read}", exc_info=True)
+                    # Error is logged, generator stops. Consumer of generator will handle abrupt end.
+                except Exception as e_stream:
+                    logger.error(f"Unexpected error during speech audio streaming for model '{model_alias}': {e_stream}", exc_info=True)
+                finally:
+                    await r.aclose()
+                    await c.aclose() # Close client after response is fully processed
+                    logger.debug(f"Speech audio stream and client closed for model '{model_alias}'")
+            
+            return (stream_generator(response, client), media_type)
+
+        except (httpx.HTTPStatusError, httpx.RequestError) as e_req_http: # Catch initial request errors
+            # These errors happen before streaming starts or if response.raise_for_status() fails
+            error_message = f"Error during initial speech synthesis request for model '{model_alias}': {e_req_http}"
+            if isinstance(e_req_http, httpx.HTTPStatusError):
+                error_message += f" - Status: {e_req_http.response.status_code}, Response: {e_req_http.response.text[:500]}"
+            logger.error(error_message, exc_info=True)
+            
+            if response: # If response object exists, ensure it's closed
+                await response.aclose()
+            await client.aclose() # Always close the client if an error occurs before returning generator
+            raise # Re-raise the caught httpx error
+        
+        except Exception as e_unexpected: # Catch any other unexpected errors during setup
+            logger.error(f"Unexpected error during speech synthesis setup for model '{model_alias}': {e_unexpected}", exc_info=True)
+            if response:
+                await response.aclose()
+            await client.aclose()
+            raise
+
+    async def transcribe_audio_advanced(
+        self,
+        model_alias: str,
+        file_name: str, 
+        file_data: bytes, 
+        content_type: str, 
+        language: Optional[str] = None,
+        prompt: Optional[str] = None,
+        response_format: Optional[str] = "json", 
+        temperature: Optional[float] = 0.0,
+        extra_form_data: Optional[Dict[str, Any]] = None, 
+        request_timeout: Optional[float] = 300.0
+    ) -> Union[Dict[str, Any], str]:
+        """
+        Transcribes audio using the specified model via LiteLLM proxy.
+
+        Args:
+            model_alias: The alias of the transcription model.
+            file_name: The original filename of the audio.
+            file_data: The raw bytes of the audio file.
+            content_type: The MIME type of the audio file.
+            language: The language of the audio.
+            prompt: An optional text prompt to guide transcription.
+            response_format: Desired output format ('json', 'text', 'srt', 'verbose_json', 'vtt').
+            temperature: Sampling temperature for transcription.
+            extra_form_data: Additional form fields for the multipart request.
+            request_timeout: Timeout for the HTTP request.
+
+        Returns:
+            A dictionary if the response format is JSON, otherwise a string.
+        
+        Raises:
+            ValueError: If LiteLLM Proxy URL is not configured.
+            httpx.HTTPStatusError: If the proxy returns an HTTP error status.
+            httpx.RequestError: If a network error occurs.
+            json.JSONDecodeError: If a JSON response was expected and parsing fails.
+        """
+        proxy_url_to_use = self.litellm_proxy_url if self.litellm_proxy_url else LITELLM_PROXY_URL
+        if not proxy_url_to_use:
+            logger.error("LiteLLM Proxy URL is not configured for transcribe_audio_advanced.")
+            raise ValueError("LiteLLM Proxy URL is not configured.")
+
+        endpoint_url = f"{proxy_url_to_use}/v1/audio/transcriptions"
+        logger.info(f"Attempting audio transcription: {endpoint_url} with model '{model_alias}', format: {response_format}")
+
+        headers = {} # Content-Type will be set by httpx for multipart/form-data
+        if LITELLM_PROXY_API_KEY:
+            headers["Authorization"] = f"Bearer {LITELLM_PROXY_API_KEY}"
+
+        data_payload = {
+            "model": model_alias,
+            "language": language,
+            "prompt": prompt,
+            "response_format": response_format,
+            "temperature": temperature,
+        }
+        if extra_form_data:
+            data_payload.update(extra_form_data)
+        
+        # Filter out None values from data_payload
+        data_payload = {k: v for k, v in data_payload.items() if v is not None}
+        logger.debug(f"LiteLLM data payload for audio transcription (model: {model_alias}): {data_payload}")
+
+        files_payload = {'file': (file_name, file_data, content_type)}
+
+        async with httpx.AsyncClient(timeout=request_timeout) as client:
+            response = None
+            try:
+                response = await client.post(
+                    endpoint_url,
+                    headers=headers,
+                    data=data_payload,
+                    files=files_payload
+                )
+                response.raise_for_status()
+                
+                # Determine how to parse based on expected response_format or Content-Type header
+                # LiteLLM's /v1/audio/transcriptions should set Content-Type appropriately
+                response_content_type = response.headers.get("Content-Type", "").lower()
+
+                if "application/json" in response_content_type:
+                    try:
+                        return response.json()
+                    except json.JSONDecodeError as e_json:
+                        logger.error(f"JSON decode error for transcription response (model '{model_alias}', format '{response_format}'): {e_json.msg}. Response text (first 500 chars): {response.text[:500]}", exc_info=False)
+                        raise
+                else: # For 'text', 'srt', 'vtt', etc.
+                    return response.text
+
+            except httpx.HTTPStatusError as e_http:
+                response_text = e_http.response.text[:500] if e_http.response else "No response body"
+                logger.error(
+                    f"HTTP error during audio transcription for model '{model_alias}' ({e_http.request.url}): "
+                    f"{e_http.response.status_code} - {response_text}", 
+                    exc_info=True
+                )
+                raise
+            except httpx.RequestError as e_req:
+                logger.error(
+                    f"Request error during audio transcription for model '{model_alias}' ({e_req.request.url}): {e_req}", 
+                    exc_info=True
+                )
+                raise
+            except Exception as e_unexpected:
+                logger.error(
+                    f"Unexpected error during audio transcription for model '{model_alias}': {e_unexpected}",
+                    exc_info=True
+                )
+                raise
+            finally:
+                if response:
+                    await response.aclose()
+                    logger.debug(f"Audio transcription response closed for model '{model_alias}' in finally block.")
+
+    async def generate_image_advanced(
+        self,
+        model_alias: str,
+        prompt: str,
+        n: Optional[int] = 1,
+        size: Optional[str] = None, 
+        quality: Optional[str] = None, 
+        style: Optional[str] = None, 
+        response_format: Optional[str] = "url", 
+        extra_body: Optional[Dict[str, Any]] = None,
+        request_timeout: Optional[float] = 120.0
+    ) -> Dict[str, Any]:
+        """
+        Generates an image using the specified model via LiteLLM proxy.
+
+        Args:
+            model_alias: The alias of the image generation model.
+            prompt: The text prompt for image generation.
+            n: The number of images to generate.
+            size: The size of the generated images (e.g., '1024x1024').
+            quality: The quality of the images ('standard', 'hd').
+            style: The style of the images ('vivid', 'natural').
+            response_format: The format of the response ('url', 'b64_json').
+            extra_body: Additional parameters for the LiteLLM request.
+            request_timeout: Timeout for the HTTP request.
+
+        Returns:
+            A dictionary representing the image generation response from LiteLLM.
+        
+        Raises:
+            ValueError: If LiteLLM Proxy URL is not configured.
+            httpx.HTTPStatusError: If the proxy returns an HTTP error status.
+            httpx.RequestError: If a network error occurs.
+            json.JSONDecodeError: If the response is not valid JSON.
+        """
+        proxy_url_to_use = self.litellm_proxy_url if self.litellm_proxy_url else LITELLM_PROXY_URL
+        if not proxy_url_to_use:
+            logger.error("LiteLLM Proxy URL is not configured for generate_image_advanced.")
+            raise ValueError("LiteLLM Proxy URL is not configured.")
+
+        endpoint_url = f"{proxy_url_to_use}/v1/images/generations"
+        logger.info(f"Attempting image generation: {endpoint_url} with model '{model_alias}'")
+
+        headers = {"Content-Type": "application/json"}
+        if LITELLM_PROXY_API_KEY:
+            headers["Authorization"] = f"Bearer {LITELLM_PROXY_API_KEY}"
+
+        litellm_payload = {
+            "model": model_alias,
+            "prompt": prompt,
+            "n": n,
+            "size": size,
+            "quality": quality,
+            "style": style,
+            "response_format": response_format,
+        }
+
+        if extra_body:
+            litellm_payload.update(extra_body)
+        
+        litellm_payload = {k: v for k, v in litellm_payload.items() if v is not None}
+        logger.debug(f"LiteLLM payload for image generation (model: {model_alias}): {litellm_payload}")
+
+        async with httpx.AsyncClient(timeout=request_timeout) as client:
+            response = None
+            try:
+                response = await client.post(
+                    endpoint_url,
+                    headers=headers,
+                    json=litellm_payload
+                )
+                response.raise_for_status()
+                
+                try:
+                    response_data = response.json()
+                except json.JSONDecodeError as e_json:
+                    logger.error(f"JSON decode error for image generation response from model '{model_alias}': {e_json.msg}. Response text (first 500 chars): {response.text[:500]}", exc_info=False)
+                    raise
+                
+                logger.info(f"Image generation successful for model '{model_alias}'.")
+                return response_data
+
+            except httpx.HTTPStatusError as e_http:
+                response_text = e_http.response.text[:500] if e_http.response else "No response body"
+                logger.error(
+                    f"HTTP error during image generation for model '{model_alias}' ({e_http.request.url}): "
+                    f"{e_http.response.status_code} - {response_text}", 
+                    exc_info=True
+                )
+                raise
+            except httpx.RequestError as e_req:
+                logger.error(
+                    f"Request error during image generation for model '{model_alias}' ({e_req.request.url}): {e_req}", 
+                    exc_info=True
+                )
+                raise
+            except Exception as e_unexpected:
+                logger.error(
+                    f"Unexpected error during image generation for model '{model_alias}': {e_unexpected}",
+                    exc_info=True
+                )
+                raise
+            finally:
+                if response:
+                    await response.aclose()
+                    logger.debug(f"Image generation response closed for model '{model_alias}' in finally block.")
+
+
+# --- Singleton Instance and Getter Function ---
+_llm_registry_instance: Optional[LLMRegistryService] = None
 
 # --- Singleton Instance and Getter Function ---
 _llm_registry_instance: Optional[LLMRegistryService] = None
@@ -519,12 +1093,27 @@ if __name__ == "__main__":
                 {"role": "user", "content": "Hello! What is the capital of France?"}
             ]
             # Example of additional kwargs:
-            # chat_kwargs = {"temperature": 0.7, "max_tokens": 50}
+            chat_kwargs = {"temperature": 0.7, "max_tokens": 50, "stream": False}
             # completion_response = await registry.get_chat_completion(test_chat_model_id, test_messages, **chat_kwargs)
-            completion_response = await registry.get_chat_completion(test_chat_model_id, test_messages)
+            completion_response_dict = await registry.chat_completion_advanced(
+                model_alias=test_chat_model_id, 
+                messages=test_messages, 
+                **chat_kwargs
+            )
 
-            if completion_response:
-                print(f"  LLM Response: {completion_response}")
+            if completion_response_dict and isinstance(completion_response_dict, dict):
+                # Extract content from the response dictionary
+                # This assumes a structure similar to OpenAI's response
+                try:
+                    content = completion_response_dict.get("choices")[0].get("message").get("content")
+                    print(f"  LLM Response: {content}")
+                except (IndexError, AttributeError, TypeError) as e_parse:
+                    print(f"  Error parsing LLM response content: {e_parse}. Full response: {completion_response_dict}")
+            elif hasattr(completion_response_dict, '__aiter__'): # If it's a stream
+                 print(f"  LLM Response is a stream. Consuming for test...")
+                 async for chunk in completion_response_dict:
+                     print(f"    Stream chunk: {chunk[:50]}...") # Print first 50 bytes of chunk
+                 print(f"  LLM Stream finished.")
             else:
                 print("  Failed to get chat completion.")
         else:

--- a/masterplan/PMOVES_AGENT_PLATFORM_PLAN.md
+++ b/masterplan/PMOVES_AGENT_PLATFORM_PLAN.md
@@ -394,6 +394,7 @@ To ensure the reliability, performance, and maintainability of the PMOVES Agent 
 - ✅ **Comprehensive Search System**: Vector, keyword, and hybrid search across all content types
 - ✅ **Content Management**: Advanced upserter with markdown, HTML, media, and video processing
 - ✅ **Multi-Provider LLM Integration**: OpenAI, Groq, Anthropic with registry-based routing
+- ✅ **Refactored LLM Interaction**: Centralized LiteLLM proxy calls within `LLMRegistryService` for improved consistency and maintainability. Implemented advanced helper methods for all LLM capabilities (chat, embeddings, vision, TTS, transcription, image generation) with comprehensive unit tests. Refactored `/llm/chat` endpoint to use the new service method. (Ongoing refactoring for other LLM routes).
 - ✅ **Real-time Processing**: SSE endpoints for live status updates and streaming responses
 - ✅ **File Management**: Secure upload, validation, PDF generation, and storage
 - ✅ **Crawl4AI Integration**: Advanced web scraping with Docker containerization

--- a/pmoves-agent-registry/app/tests/test_agent_registry.py
+++ b/pmoves-agent-registry/app/tests/test_agent_registry.py
@@ -1,0 +1,394 @@
+import unittest
+import os
+from unittest.mock import patch, MagicMock, call
+from datetime import datetime, timezone
+import json
+
+# Assuming models and schemas are in pmoves-agent-registry.app
+from pmoves_agent_registry.app.models import AgentStore
+from pmoves_agent_registry.app.schemas import AgentRegistration, AgentMetadata
+from supabase.lib.client_options import PostgrestAPIError
+
+class TestAgentStore(unittest.TestCase):
+
+    @patch.dict(os.environ, {"SUPABASE_URL": "mock_url", "SUPABASE_KEY": "mock_key"})
+    @patch('pmoves_agent_registry.app.models.create_client')
+    def setUp(self, mock_create_client):
+        self.mock_supabase_client = MagicMock()
+        mock_create_client.return_value = self.mock_supabase_client
+        self.agent_store = AgentStore()
+        
+        # Common mock data
+        self.agent_id = "test_agent_001"
+        self.now = datetime.now(timezone.utc)
+        self.base_agent_data = {
+            "agent_id": self.agent_id,
+            "name": "Test Agent",
+            "description": "A test agent",
+            "capabilities": ["test", "mock"],
+            "input_schema": {"type": "object"},
+            "output_schema": {"type": "object"},
+            "status": "active",
+            "endpoint": "http://localhost:8000/agent",
+            "dependencies": ["dep1"],
+            "version": "1.0",
+            "tags": ["test_env"],
+            "last_heartbeat": self.now,
+            "config": {"key": "value"}
+        }
+        self.agent_reg = AgentRegistration(**self.base_agent_data)
+        self.agent_meta = AgentMetadata(**self.base_agent_data)
+
+    # Test __init__
+    @patch.dict(os.environ, {"SUPABASE_URL": "mock_url", "SUPABASE_KEY": "mock_key"})
+    @patch('pmoves_agent_registry.app.models.create_client')
+    def test_init_success(self, mock_create_client_success):
+        mock_client = MagicMock()
+        mock_create_client_success.return_value = mock_client
+        store = AgentStore()
+        self.assertIsNotNone(store.db)
+        self.assertEqual(store.db, mock_client)
+        mock_create_client_success.assert_called_once_with("mock_url", "mock_key")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_init_missing_env_vars(self):
+        with self.assertRaises(ValueError) as context:
+            AgentStore()
+        self.assertIn("SUPABASE_URL and SUPABASE_KEY must be set", str(context.exception))
+
+    @patch.dict(os.environ, {"SUPABASE_URL": "mock_url", "SUPABASE_KEY": "mock_key"})
+    @patch('pmoves_agent_registry.app.models.create_client', side_effect=Exception("Init failed"))
+    def test_init_supabase_client_exception(self, mock_create_client_fail):
+        with self.assertRaises(Exception) as context:
+            AgentStore()
+        self.assertIn("Init failed", str(context.exception))
+
+    # Test _serialize_agent_data
+    def test_serialize_agent_data_full(self):
+        data_to_serialize = self.agent_meta.dict()
+        serialized = self.agent_store._serialize_agent_data(data_to_serialize)
+        
+        self.assertEqual(serialized['agent_id'], self.agent_id)
+        self.assertEqual(serialized['capabilities'], json.dumps(self.base_agent_data['capabilities']))
+        self.assertEqual(serialized['input_schema'], json.dumps(self.base_agent_data['input_schema']))
+        self.assertEqual(serialized['output_schema'], json.dumps(self.base_agent_data['output_schema']))
+        self.assertEqual(serialized['dependencies'], json.dumps(self.base_agent_data['dependencies']))
+        self.assertEqual(serialized['tags'], json.dumps(self.base_agent_data['tags']))
+        self.assertEqual(serialized['config'], json.dumps(self.base_agent_data['config']))
+        self.assertEqual(serialized['last_heartbeat'], self.base_agent_data['last_heartbeat'].isoformat())
+
+    def test_serialize_agent_data_partial_and_none(self):
+        partial_data = {
+            "agent_id": "agent_002",
+            "name": "Partial Agent",
+            "capabilities": None, # Test None
+            "input_schema": {"type": "string"}, # Test present
+            # output_schema is missing
+        }
+        serialized = self.agent_store._serialize_agent_data(partial_data)
+        self.assertEqual(serialized['agent_id'], "agent_002")
+        self.assertIsNone(serialized['capabilities'])
+        self.assertEqual(serialized['input_schema'], json.dumps({"type": "string"}))
+        self.assertNotIn('output_schema', serialized) # Should not add missing fields
+
+    # Test _deserialize_agent_data
+    def test_deserialize_agent_data_full(self):
+        serialized_data = {
+            **self.base_agent_data, # Start with original types
+            'capabilities': json.dumps(self.base_agent_data['capabilities']),
+            'input_schema': json.dumps(self.base_agent_data['input_schema']),
+            'output_schema': json.dumps(self.base_agent_data['output_schema']),
+            'dependencies': json.dumps(self.base_agent_data['dependencies']),
+            'tags': json.dumps(self.base_agent_data['tags']),
+            'config': json.dumps(self.base_agent_data['config']),
+            'last_heartbeat': self.base_agent_data['last_heartbeat'].isoformat()
+        }
+        deserialized = self.agent_store._deserialize_agent_data(serialized_data)
+        self.assertEqual(deserialized['agent_id'], self.agent_id)
+        self.assertEqual(deserialized['capabilities'], self.base_agent_data['capabilities'])
+        self.assertEqual(deserialized['input_schema'], self.base_agent_data['input_schema'])
+        self.assertEqual(deserialized['output_schema'], self.base_agent_data['output_schema'])
+        self.assertEqual(deserialized['dependencies'], self.base_agent_data['dependencies'])
+        self.assertEqual(deserialized['tags'], self.base_agent_data['tags'])
+        self.assertEqual(deserialized['config'], self.base_agent_data['config'])
+        self.assertEqual(deserialized['last_heartbeat'], self.base_agent_data['last_heartbeat'])
+
+    def test_deserialize_agent_data_partial_and_pre_typed(self):
+        data = {
+            "agent_id": "agent_003",
+            "name": "Pre-typed Agent",
+            "capabilities": ["already_list"], # Already a list
+            "input_schema": None, # Test None
+            # output_schema is missing
+        }
+        deserialized = self.agent_store._deserialize_agent_data(data)
+        self.assertEqual(deserialized['capabilities'], ["already_list"])
+        self.assertIsNone(deserialized['input_schema'])
+
+    @patch('builtins.print')
+    def test_deserialize_agent_data_json_decode_error(self, mock_print):
+        data_with_bad_json = {
+            "agent_id": "agent_004",
+            "name": "Bad JSON Agent",
+            "capabilities": "{not_json_at_all",
+            "last_heartbeat": self.now.isoformat()
+        }
+        deserialized = self.agent_store._deserialize_agent_data(data_with_bad_json)
+        self.assertEqual(deserialized['capabilities'], "{not_json_at_all") # Stays as string
+        self.assertEqual(deserialized['last_heartbeat'], self.now)
+        mock_print.assert_called_with("Warning: Could not decode JSON for field capabilities for agent agent_004")
+
+    # Test register
+    def test_register_success(self):
+        mock_response = MagicMock()
+        # Simulate Supabase returning the inserted data, which needs deserialization by AgentMetadata
+        raw_db_return = self.agent_store._serialize_agent_data(self.agent_meta.dict())
+        mock_response.data = [raw_db_return] # Supabase returns a list
+        self.mock_supabase_client.table().upsert().execute.return_value = mock_response
+
+        with patch.object(self.agent_store, '_serialize_agent_data', wraps=self.agent_store._serialize_agent_data) as mock_serialize, \
+             patch.object(self.agent_store, '_deserialize_agent_data', wraps=self.agent_store._deserialize_agent_data) as mock_deserialize:
+            
+            # The input to register is AgentRegistration, but it becomes AgentMetadata internally
+            # before serialization, so we use agent_meta for comparison after deserialization.
+            registered_agent = self.agent_store.register(self.agent_reg)
+
+            self.assertIsNotNone(registered_agent)
+            self.assertIsInstance(registered_agent, AgentMetadata)
+            # Compare all fields of AgentMetadata
+            for key in AgentMetadata.__fields__.keys():
+                 self.assertEqual(getattr(registered_agent, key), getattr(self.agent_meta, key))
+
+            mock_serialize.assert_called_once()
+            # The AgentMetadata constructor calls .dict() which might trigger _deserialize_agent_data if fields are complex
+            # and then response.data[0] is passed to _deserialize_agent_data
+            self.assertTrue(mock_deserialize.call_count >= 1) 
+            self.mock_supabase_client.table("agents").upsert.assert_called_once()
+            
+            # Check that the data passed to upsert had last_heartbeat set
+            # The actual call to upsert is with the serialized data
+            args, kwargs = self.mock_supabase_client.table("agents").upsert.call_args
+            upsert_data = args[0] 
+            self.assertIn('last_heartbeat', upsert_data)
+            self.assertIsNotNone(upsert_data['last_heartbeat'])
+
+
+    def test_register_supabase_api_error(self):
+        self.mock_supabase_client.table().upsert().execute.side_effect = PostgrestAPIError("DB error")
+        result = self.agent_store.register(self.agent_reg)
+        self.assertIsNone(result)
+
+    def test_register_generic_exception(self):
+        self.mock_supabase_client.table().upsert().execute.side_effect = Exception("Generic error")
+        result = self.agent_store.register(self.agent_reg)
+        self.assertIsNone(result)
+
+    def test_register_supabase_no_data_response(self):
+        mock_response = MagicMock()
+        mock_response.data = [] # Empty list
+        self.mock_supabase_client.table().upsert().execute.return_value = mock_response
+        result = self.agent_store.register(self.agent_reg)
+        self.assertIsNone(result)
+
+    # Test get
+    def test_get_success(self):
+        mock_response = MagicMock()
+        serialized_agent_data = self.agent_store._serialize_agent_data(self.agent_meta.dict())
+        mock_response.data = [serialized_agent_data]
+        self.mock_supabase_client.table().select().eq().limit().execute.return_value = mock_response
+
+        with patch.object(self.agent_store, '_deserialize_agent_data', wraps=self.agent_store._deserialize_agent_data) as mock_deserialize:
+            agent = self.agent_store.get(self.agent_id)
+            self.assertIsNotNone(agent)
+            self.assertIsInstance(agent, AgentMetadata)
+            self.assertEqual(agent.agent_id, self.agent_id)
+            for key in AgentMetadata.__fields__.keys():
+                 self.assertEqual(getattr(agent, key), getattr(self.agent_meta, key))
+            mock_deserialize.assert_called_once_with(serialized_agent_data)
+        self.mock_supabase_client.table("agents").select("*").eq("agent_id", self.agent_id).limit(1).execute.assert_called_once()
+
+
+    def test_get_not_found(self):
+        mock_response = MagicMock()
+        mock_response.data = []
+        self.mock_supabase_client.table().select().eq().limit().execute.return_value = mock_response
+        agent = self.agent_store.get("unknown_id")
+        self.assertIsNone(agent)
+
+    def test_get_supabase_api_error(self):
+        self.mock_supabase_client.table().select().eq().limit().execute.side_effect = PostgrestAPIError("DB error")
+        agent = self.agent_store.get(self.agent_id)
+        self.assertIsNone(agent)
+
+    def test_get_generic_exception(self):
+        self.mock_supabase_client.table().select().eq().limit().execute.side_effect = Exception("Generic error")
+        agent = self.agent_store.get(self.agent_id)
+        self.assertIsNone(agent)
+
+    # Test list
+    def test_list_success_multiple_agents(self):
+        agent2_data = {**self.base_agent_data, "agent_id": "agent_002", "name": "Agent Two"}
+        agent_meta2 = AgentMetadata(**agent2_data)
+
+        serialized_agent1 = self.agent_store._serialize_agent_data(self.agent_meta.dict())
+        serialized_agent2 = self.agent_store._serialize_agent_data(agent_meta2.dict())
+        
+        mock_response = MagicMock()
+        mock_response.data = [serialized_agent1, serialized_agent2]
+        self.mock_supabase_client.table().select().execute.return_value = mock_response
+
+        with patch.object(self.agent_store, '_deserialize_agent_data', wraps=self.agent_store._deserialize_agent_data) as mock_deserialize:
+            agents = self.agent_store.list()
+            self.assertEqual(len(agents), 2)
+            self.assertIsInstance(agents[0], AgentMetadata)
+            self.assertIsInstance(agents[1], AgentMetadata)
+            self.assertEqual(agents[0].agent_id, self.agent_id)
+            self.assertEqual(agents[1].agent_id, "agent_002")
+            self.assertEqual(mock_deserialize.call_count, 2)
+            mock_deserialize.assert_any_call(serialized_agent1)
+            mock_deserialize.assert_any_call(serialized_agent2)
+        self.mock_supabase_client.table("agents").select("*").execute.assert_called_once()
+
+    def test_list_no_agents(self):
+        mock_response = MagicMock()
+        mock_response.data = []
+        self.mock_supabase_client.table().select().execute.return_value = mock_response
+        agents = self.agent_store.list()
+        self.assertEqual(len(agents), 0)
+
+    def test_list_supabase_api_error(self):
+        self.mock_supabase_client.table().select().execute.side_effect = PostgrestAPIError("DB error")
+        agents = self.agent_store.list()
+        self.assertEqual(len(agents), 0)
+
+    def test_list_generic_exception(self):
+        self.mock_supabase_client.table().select().execute.side_effect = Exception("Generic error")
+        agents = self.agent_store.list()
+        self.assertEqual(len(agents), 0)
+
+    # Test heartbeat
+    def test_heartbeat_success(self):
+        new_heartbeat_time = datetime.now(timezone.utc)
+        
+        # Mock for the update call
+        mock_update_response = MagicMock()
+        # Supabase update might return the updated record(s)
+        updated_raw_data = self.agent_store._serialize_agent_data({
+            **self.agent_meta.dict(), 
+            "last_heartbeat": new_heartbeat_time, 
+            "status": "active"
+        })
+        mock_update_response.data = [updated_raw_data] # Assuming it returns the updated record
+        self.mock_supabase_client.table().update().eq().execute.return_value = mock_update_response
+
+        # Mock for the self.get call within heartbeat
+        # This get call should return the fully updated agent
+        mock_get_response = MagicMock()
+        # The data returned by get() should be what AgentMetadata expects after deserialization
+        final_agent_data_for_get = AgentMetadata(**{
+            **self.agent_meta.dict(), 
+            "last_heartbeat": new_heartbeat_time, 
+            "status": "active"
+        }).dict()
+        # self.get will deserialize this, so provide serialized version for its mock
+        mock_get_response.data = [self.agent_store._serialize_agent_data(final_agent_data_for_get)]
+        
+        # Configure the mock_supabase_client to handle both the update and the subsequent select from get()
+        # The first execute() is for update, the second for select().eq().limit().execute() from self.get()
+        self.mock_supabase_client.table().update().eq().execute.return_value = mock_update_response
+        # For the self.get call:
+        self.mock_supabase_client.table().select().eq().limit().execute.return_value = mock_get_response
+        
+        with patch.object(self.agent_store, 'get', wraps=self.agent_store.get) as mock_get_method:
+            updated_agent = self.agent_store.heartbeat(self.agent_id, new_heartbeat_time)
+
+            self.assertIsNotNone(updated_agent)
+            self.assertEqual(updated_agent.agent_id, self.agent_id)
+            self.assertEqual(updated_agent.last_heartbeat, new_heartbeat_time)
+            self.assertEqual(updated_agent.status, "active")
+
+            # Check that update was called with correct data
+            args, kwargs = self.mock_supabase_client.table("agents").update.call_args
+            update_payload = args[0]
+            self.assertEqual(update_payload["last_heartbeat"], new_heartbeat_time.isoformat())
+            self.assertEqual(update_payload["status"], "active")
+            self.assertIn("updated_at", update_payload) # Check that updated_at is being set
+
+            self.mock_supabase_client.table("agents").update(update_payload).eq("agent_id", self.agent_id).execute.assert_called_once()
+            mock_get_method.assert_called_once_with(self.agent_id)
+
+
+    def test_heartbeat_agent_not_found(self):
+        # Update returns no data
+        mock_update_response = MagicMock()
+        mock_update_response.data = []
+        self.mock_supabase_client.table().update().eq().execute.return_value = mock_update_response
+        
+        # self.get also returns None
+        with patch.object(self.agent_store, 'get', return_value=None) as mock_get_method:
+            result = self.agent_store.heartbeat("unknown_id", self.now)
+            self.assertIsNone(result)
+            mock_get_method.assert_called_once_with("unknown_id") # get is called to confirm non-existence
+
+    @patch('builtins.print')
+    def test_heartbeat_update_returns_no_data_agent_exists(self, mock_print):
+        # Update returns no data
+        mock_update_response = MagicMock()
+        mock_update_response.data = []
+        self.mock_supabase_client.table().update().eq().execute.return_value = mock_update_response
+
+        # But self.get returns the agent (as if update failed to return data but agent is there)
+        # The agent_meta here would be the state *before* the heartbeat update was meant to apply
+        with patch.object(self.agent_store, 'get', return_value=self.agent_meta) as mock_get_method:
+            result = self.agent_store.heartbeat(self.agent_id, self.now)
+            
+            self.assertIsNotNone(result)
+            # Should return the existing agent data if update returned nothing but agent exists
+            self.assertEqual(result.agent_id, self.agent_meta.agent_id)
+            self.assertEqual(result.last_heartbeat, self.agent_meta.last_heartbeat) # Unchanged
+            
+            mock_get_method.assert_called_once_with(self.agent_id)
+            mock_print.assert_any_call(f"Warning: Supabase heartbeat update for agent {self.agent_id} returned no data. Current data: {self.agent_meta}")
+
+
+    def test_heartbeat_supabase_api_error(self):
+        self.mock_supabase_client.table().update().eq().execute.side_effect = PostgrestAPIError("DB error")
+        result = self.agent_store.heartbeat(self.agent_id, self.now)
+        self.assertIsNone(result)
+
+    def test_heartbeat_generic_exception(self):
+        self.mock_supabase_client.table().update().eq().execute.side_effect = Exception("Generic error")
+        result = self.agent_store.heartbeat(self.agent_id, self.now)
+        self.assertIsNone(result)
+
+    # Test deregister
+    def test_deregister_success(self):
+        mock_response = MagicMock()
+        # Supabase delete can return the deleted rows
+        mock_response.data = [self.agent_store._serialize_agent_data(self.agent_meta.dict())] 
+        self.mock_supabase_client.table().delete().eq().execute.return_value = mock_response
+        
+        result = self.agent_store.deregister(self.agent_id)
+        self.assertTrue(result)
+        self.mock_supabase_client.table("agents").delete().eq("agent_id", self.agent_id).execute.assert_called_once()
+
+    def test_deregister_non_existent_agent(self):
+        mock_response = MagicMock()
+        mock_response.data = [] # No data indicates agent not found or already deleted
+        self.mock_supabase_client.table().delete().eq().execute.return_value = mock_response
+        
+        result = self.agent_store.deregister("unknown_id")
+        self.assertFalse(result)
+
+    def test_deregister_supabase_api_error(self):
+        self.mock_supabase_client.table().delete().eq().execute.side_effect = PostgrestAPIError("DB error")
+        result = self.agent_store.deregister(self.agent_id)
+        self.assertFalse(result)
+
+    def test_deregister_generic_exception(self):
+        self.mock_supabase_client.table().delete().eq().execute.side_effect = Exception("Generic error")
+        result = self.agent_store.deregister(self.agent_id)
+        self.assertFalse(result)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pmoves-agent-registry/app/tests/test_integration_agent_registry.py
+++ b/pmoves-agent-registry/app/tests/test_integration_agent_registry.py
@@ -1,0 +1,207 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+from pmoves_agent_registry.app.main import app
+from pmoves_agent_registry.app.schemas import AgentMetadata, AgentRegistration, AgentHeartbeat
+from datetime import datetime, timezone
+
+# Patching agent_store where it's imported and used in main.py
+@patch('pmoves_agent_registry.app.main.agent_store', new_callable=MagicMock)
+class TestAgentRegistryIntegration(unittest.TestCase):
+
+    def setUp(self):
+        self.client = TestClient(app)
+        # Define common test data
+        self.agent_id = "test_agent_001"
+        self.now = datetime.now(timezone.utc)
+        
+        # This dictionary represents the expected JSON structure for an AgentMetadata object
+        # Useful for comparing against response.json()
+        self.base_agent_dict_json_compatible = {
+            "agent_id": self.agent_id,
+            "name": "Test Agent",
+            "description": "A test agent",
+            "capabilities": ["test", "mock"],
+            "input_schema": {"type": "object"},
+            "output_schema": {"type": "object"},
+            "status": "active",
+            "endpoint": "http://localhost:8000/agent",
+            "dependencies": ["dep1"],
+            "version": "1.0",
+            "tags": ["test_env"],
+            "last_heartbeat": self.now.isoformat(), # JSON uses ISO string for datetime
+            "config": {"key": "value"}
+        }
+        
+        # This is the Pydantic model instance that mock agent_store methods will return
+        self.mock_agent_metadata_object = AgentMetadata(
+            agent_id=self.agent_id,
+            name="Test Agent",
+            description="A test agent",
+            capabilities=["test", "mock"],
+            input_schema={"type": "object"},
+            output_schema={"type": "object"},
+            status="active",
+            endpoint="http://localhost:8000/agent",
+            dependencies=["dep1"],
+            version="1.0",
+            tags=["test_env"],
+            last_heartbeat=self.now, # Pydantic model uses datetime object
+            config={"key": "value"}
+        )
+
+    # Test GET /agents
+    def test_list_agents_empty(self, mock_agent_store: MagicMock):
+        mock_agent_store.list.return_value = []
+        response = self.client.get("/agents")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), [])
+        mock_agent_store.list.assert_called_once()
+
+    def test_list_agents_with_data(self, mock_agent_store: MagicMock):
+        mock_data_list = [self.mock_agent_metadata_object]
+        mock_agent_store.list.return_value = mock_data_list
+        
+        response = self.client.get("/agents")
+        self.assertEqual(response.status_code, 200)
+        
+        response_json = response.json()
+        self.assertEqual(len(response_json), 1)
+        # Compare the first item with the JSON compatible dict
+        self.assertEqual(response_json[0], self.base_agent_dict_json_compatible)
+        mock_agent_store.list.assert_called_once()
+
+    # Test GET /agents/{agent_id}
+    def test_get_agent_by_id_success(self, mock_agent_store: MagicMock):
+        mock_agent_store.get.return_value = self.mock_agent_metadata_object
+        
+        response = self.client.get(f"/agents/{self.agent_id}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), self.base_agent_dict_json_compatible)
+        mock_agent_store.get.assert_called_once_with(self.agent_id)
+
+    def test_get_agent_by_id_not_found(self, mock_agent_store: MagicMock):
+        mock_agent_store.get.return_value = None
+        response = self.client.get("/agents/unknown_agent")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {"detail": "Agent not found"})
+        mock_agent_store.get.assert_called_once_with("unknown_agent")
+
+    # Test POST /agents/register
+    def test_register_agent_success(self, mock_agent_store: MagicMock):
+        # This is the payload sent by the client, conforming to AgentRegistration
+        reg_data_payload = {
+            "agent_id": self.agent_id,
+            "name": "Test Agent",
+            "description": "A test agent",
+            "capabilities": ["test", "mock"],
+            "input_schema": {"type": "object"},
+            "output_schema": {"type": "object"},
+            "status": "active", # Initial status
+            "endpoint": "http://localhost:8000/agent",
+            "dependencies": ["dep1"],
+            "version": "1.0",
+            "tags": ["test_env"],
+            # "last_heartbeat" is not provided by client in registration
+            "config": {"key": "value"}
+            # No last_heartbeat here
+        }
+        
+        # agent_store.register is expected to return a full AgentMetadata object
+        # which includes last_heartbeat set by the server.
+        mock_agent_store.register.return_value = self.mock_agent_metadata_object
+        
+        response = self.client.post("/agents/register", json=reg_data_payload)
+        self.assertEqual(response.status_code, 200) # As per main.py, returns the object
+        self.assertEqual(response.json(), self.base_agent_dict_json_compatible) # Response should match full metadata
+        
+        mock_agent_store.register.assert_called_once()
+        call_args = mock_agent_store.register.call_args[0][0]
+        self.assertIsInstance(call_args, AgentRegistration)
+        self.assertEqual(call_args.agent_id, self.agent_id)
+        # Ensure that the AgentRegistration model passed to store has no last_heartbeat (or is None)
+        self.assertIsNone(call_args.last_heartbeat)
+
+
+    def test_register_agent_invalid_input_missing_field(self, mock_agent_store: MagicMock):
+        invalid_payload = {"name": "Test Agent Only"} # Missing agent_id, description, etc.
+        response = self.client.post("/agents/register", json=invalid_payload)
+        self.assertEqual(response.status_code, 422) # Unprocessable Entity
+        mock_agent_store.register.assert_not_called()
+
+    def test_register_agent_store_returns_none(self, mock_agent_store: MagicMock):
+        # Minimal valid payload for AgentRegistration
+        reg_data_payload = {
+            "agent_id": "agent_minimal", "name": "Minimal Agent", "description": "Desc",
+            "capabilities": [], "input_schema": {}, "output_schema": {}, "status": "pending"
+        } 
+        
+        mock_agent_store.register.return_value = None # Simulate agent_store failing to register
+        
+        response = self.client.post("/agents/register", json=reg_data_payload)
+        # Current main.py returns the result of agent_store.register directly.
+        # If it's None, FastAPI will return a 200 OK with a JSON `null` body.
+        self.assertEqual(response.status_code, 200) 
+        self.assertIsNone(response.json()) # Body should be null
+        mock_agent_store.register.assert_called_once()
+
+    # Test POST /agents/heartbeat
+    def test_heartbeat_success(self, mock_agent_store: MagicMock):
+        heartbeat_payload = {"agent_id": self.agent_id, "timestamp": self.now.isoformat()}
+        
+        # Simulate heartbeat returning the updated agent metadata
+        # For this test, we assume the heartbeat logic in agent_store updates the last_heartbeat
+        # and returns the full AgentMetadata. The self.mock_agent_metadata_object already has 'now'
+        # as its last_heartbeat, so it serves as a valid return object.
+        mock_agent_store.heartbeat.return_value = self.mock_agent_metadata_object
+        
+        response = self.client.post("/agents/heartbeat", json=heartbeat_payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), self.base_agent_dict_json_compatible)
+        
+        mock_agent_store.heartbeat.assert_called_once()
+        call_args = mock_agent_store.heartbeat.call_args[0][0]
+        self.assertIsInstance(call_args, AgentHeartbeat)
+        self.assertEqual(call_args.agent_id, self.agent_id)
+        # FastAPI/Pydantic converts ISO string to datetime for the model
+        self.assertEqual(call_args.timestamp, self.now)
+
+
+    def test_heartbeat_agent_not_found(self, mock_agent_store: MagicMock):
+        mock_agent_store.heartbeat.return_value = None
+        heartbeat_payload = {"agent_id": "unknown_agent", "timestamp": self.now.isoformat()}
+        
+        response = self.client.post("/agents/heartbeat", json=heartbeat_payload)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {"detail": "Agent not found or heartbeat failed"})
+        
+        mock_agent_store.heartbeat.assert_called_once()
+        call_args = mock_agent_store.heartbeat.call_args[0][0]
+        self.assertEqual(call_args.agent_id, "unknown_agent")
+
+
+    def test_heartbeat_invalid_input(self, mock_agent_store: MagicMock):
+        invalid_payload = {"timestamp": self.now.isoformat()} # Missing agent_id
+        response = self.client.post("/agents/heartbeat", json=invalid_payload)
+        self.assertEqual(response.status_code, 422)
+        mock_agent_store.heartbeat.assert_not_called()
+
+    # Test DELETE /agents/{agent_id}
+    def test_deregister_agent_success(self, mock_agent_store: MagicMock):
+        mock_agent_store.deregister.return_value = True
+        response = self.client.delete(f"/agents/{self.agent_id}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"detail": "Agent deregistered"})
+        mock_agent_store.deregister.assert_called_once_with(self.agent_id)
+
+    def test_deregister_agent_not_found(self, mock_agent_store: MagicMock):
+        mock_agent_store.deregister.return_value = False
+        response = self.client.delete("/agents/unknown_agent")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {"detail": "Agent not found"})
+        mock_agent_store.deregister.assert_called_once_with("unknown_agent")
+
+if __name__ == '__main__':
+    # This allows running the tests directly from the file, e.g., `python test_integration_agent_registry.py`
+    # The `argv` and `exit` parameters are to ensure compatibility with different execution environments.
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
This commit completes the refactoring of LLM interaction logic. It centralizes calls to the LiteLLM proxy within LLMRegistryService and updates the LLM routes to use this service. Comprehensive tests have been added at both the unit and integration levels.

**Phase 1: Enhanced `llm_registry_service.py`**

- I added new "advanced" helper methods to `LLMRegistryService` for all core LLM operations:
    - `chat_completion_advanced` (handles streaming)
    - `create_embeddings_advanced`
    - `analyze_vision_advanced`
    - `synthesize_speech_advanced` (handles streaming)
    - `transcribe_audio_advanced` (handles multipart/form-data)
    - `generate_image_advanced`
- These methods encapsulate payload construction, HTTP calls to LiteLLM (via httpx), and error handling.
- I created `backend/app/tests/utils/test_llm_registry_service.py` with comprehensive unit tests for all new advanced helper methods, mocking `httpx.AsyncClient`.

**Phase 2: Refactored `llm_routes.py`**

- I modified the following LLM endpoints in `backend/app/routes/llm_routes.py` to delegate logic to the corresponding `LLMRegistryService` advanced helper methods:
    - `/llm/chat`
    - `/llm/embeddings`
    - `/llm/vision-analyze`
    - `/llm/text-to-speech`
    - `/llm/transcribe-audio` (includes removal of temporary file handling)
    - `/llm/generate-image`
- Error handling in routes adapted to catch exceptions from the service layer.
- I created `backend/app/tests/routes/test_llm_routes.py` with new integration tests for all LLM endpoints.
    - Tests for refactored routes mock `LLMRegistryService` methods via FastAPI dependency overrides.
    - Tests for the non-refactored `/llm/text-completion` route continue to mock `httpx.AsyncClient`.
- I performed code cleanup:
    - Removed old, simpler helper methods (`get_chat_completion`, `transcribe_audio`) from `LLMRegistryService` and updated its `if __name__ == "__main__"` block.
    - Deleted unused imports and variables (related to old direct httpx calls and temp files) from `llm_routes.py`.

**Documentation:**

- I updated `masterplan/PMOVES_AGENT_PLATFORM_PLAN.md` to reflect the progress in refactoring LLM interactions.

This refactoring improves code structure, maintainability, and testability by centralizing LLM proxy interactions.