### PR TITLE
fix: Add missing typing imports to LLMRegistryService

### DIFF
--- a/backend/app/utils/llm_registry_service.py
+++ b/backend/app/utils/llm_registry_service.py
@@ -5,7 +5,7 @@ import time
 
 logger = logging.getLogger(__name__) # Define logger at the top
 from datetime import datetime, timezone, timedelta
-from typing import Optional, List, Dict, Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple, Union # Consolidated and sorted
 
 import httpx
 from pydantic import BaseModel, Field, field_validator


### PR DESCRIPTION
Resolves a NameError (e.g., "name 'Union' is not defined") that occurred because typing hints like Union, Tuple, etc., were used in method signatures within LLMRegistryService without being imported from the `typing` module.

The import statement in `backend/app/utils/llm_registry_service.py` has been updated to include all necessary types.