### PR TITLE
Disable API key middleware

### DIFF
--- a/backend/app/main copy.py
+++ b/backend/app/main copy.py
@@ -313,7 +313,6 @@ try:
     from .ollama_initializer import (
         ensure_ollama_model_loaded,
     )
-    from .middleware.security_middleware import APIKeySecurityMiddleware
 
     PROJECT_MODULES_LOADED = True
 except ImportError as e:
@@ -829,8 +828,6 @@ app.add_middleware(
 )
 
 # --- Add Custom Middlewares ---
-app.add_middleware(APIKeySecurityMiddleware)
-logger.info("APIKeySecurityMiddleware enabled.")
 
 if (
     PROJECT_MODULES_LOADED

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -313,7 +313,6 @@ try:
     from .ollama_initializer import (
         ensure_ollama_model_loaded,
     )
-    from .middleware.security_middleware import APIKeySecurityMiddleware
 
     PROJECT_MODULES_LOADED = True
 except ImportError as e:
@@ -829,8 +828,6 @@ app.add_middleware(
 )
 
 # --- Add Custom Middlewares ---
-app.add_middleware(APIKeySecurityMiddleware)
-logger.info("APIKeySecurityMiddleware enabled.")
 
 if (
     PROJECT_MODULES_LOADED

--- a/backend/app/middleware/security_middleware.py
+++ b/backend/app/middleware/security_middleware.py
@@ -75,16 +75,19 @@ if not ALLOWED_API_KEYS:
     )
 
 
+DISABLE_API_KEY_MIDDLEWARE = os.getenv("DISABLE_API_KEY_MIDDLEWARE", "false").lower() == "true"
+
+
 class APIKeySecurityMiddleware(BaseHTTPMiddleware):
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
-        logger.warning(
-            "DEVELOPMENT MODE: APIKeySecurityMiddleware is currently DISABLED. All requests are being allowed without API key authentication."
-        )
-        # Bypass all security checks
-        response = await call_next(request)
-        return response
+        if DISABLE_API_KEY_MIDDLEWARE:
+            logger.warning(
+                "DEVELOPMENT MODE: APIKeySecurityMiddleware is currently DISABLED. All requests are being allowed without API key authentication."
+            )
+            response = await call_next(request)
+            return response
 
         # Check if the current request path is in EXEMPT_PATHS or starts with an EXEMPT_PREFIX
         if request.url.path in EXEMPT_PATHS or any(


### PR DESCRIPTION
## Summary
- remove APIKeySecurityMiddleware from backend app
- keep middleware code but do not register it

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684e42f783008325a1e57f775d1a8690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an environment variable to enable or disable API key authentication middleware dynamically.

- **Chores**
  - Removed API key authentication middleware from the application setup by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->